### PR TITLE
Fix notification targets displayed empty deffect192

### DIFF
--- a/vector/src/main/java/im/vector/fragments/VectorSettingsPreferencesFragment.java
+++ b/vector/src/main/java/im/vector/fragments/VectorSettingsPreferencesFragment.java
@@ -788,15 +788,7 @@ public class VectorSettingsPreferencesFragment extends PreferenceFragment {
 
         if (isNewList) {
             // remove the displayed one
-            for (int index = 0; ; index++) {
-                Preference preference = mPushersSettingsCategory.findPreference(PUSHER_PREREFENCE_KEY_BASE + index);
-
-                if (null != preference) {
-                    mPushersSettingsCategory.removePreference(preference);
-                } else {
-                    break;
-                }
-            }
+            mPushersSettingsCategory.removeAll();
 
             // add new emails list
             mDisplayedPushers = pushersList;
@@ -806,11 +798,16 @@ public class VectorSettingsPreferencesFragment extends PreferenceFragment {
             for (Pusher pusher : mDisplayedPushers) {
                 VectorCustomActionEditTextPreference preference = new VectorCustomActionEditTextPreference(getActivity());
 
-                preference.setTitle(pusher.deviceDisplayName);
-                preference.setSummary(pusher.appDisplayName);
-                preference.setKey(PUSHER_PREREFENCE_KEY_BASE + index);
-                index++;
-                mPushersSettingsCategory.addPreference(preference);
+                // fix https://github.com/vector-im/vector-android/issues/192
+                // It appears that the server sends some invalid pushers where the device and the app are
+                // invalid. In all these cases the language is set to null.
+                if(null != pusher.lang) {
+                    preference.setTitle(pusher.deviceDisplayName);
+                    preference.setSummary(pusher.appDisplayName);
+                    preference.setKey(PUSHER_PREREFENCE_KEY_BASE + index);
+                    index++;
+                    mPushersSettingsCategory.addPreference(preference);
+                }
             }
         }
     }

--- a/vector/src/main/res/layout/activity_vector_settings.xml
+++ b/vector/src/main/res/layout/activity_vector_settings.xml
@@ -8,18 +8,17 @@
         android:background="@color/room_background"
         android:id="@+id/vector_settings_page" />
 
-    <RelativeLayout
+    <FrameLayout
         android:id="@+id/vector_settings_spinner_views"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:visibility="gone"
-        android:background="#449D9D9D">
+        android:background="@color/chat_encoding_background">
         <ProgressBar
-            android:id="@+id/listView_spinner"
+            android:id="@+id/vector_settings_spinner"
             android:layout_width="40dp"
             android:layout_height="40dp"
-            android:layout_centerHorizontal="true"
-            android:layout_centerVertical="true"
+            android:layout_gravity="center"
             android:visibility="visible"/>
-    </RelativeLayout>
+    </FrameLayout>
 </FrameLayout>


### PR DESCRIPTION
- fix defect #192 
- fix waiting spinner screen in the vector settings screen (when the waiting screen was displayed, it was still possible access the settings)