### PR TITLE
Change registration field placeholder from 'Your name' to 'User name'

### DIFF
--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -147,7 +147,7 @@
     <string name="auth_user_id_placeholder">Email or user name</string>
     <string name="auth_password_placeholder">Password</string>
     <string name="auth_new_password_placeholder">New password</string>
-    <string name="auth_user_name_placeholder">Your name</string>
+    <string name="auth_user_name_placeholder">User name</string>
     <string name="auth_email_placeholder">Email address</string>
     <string name="auth_repeat_password_placeholder">Repeat password</string>
     <string name="auth_repeat_new_password_placeholder">Confirm your new password</string>


### PR DESCRIPTION
Changed the placeholder string used in registration form from `Your name` to `User name`.

When I created my account, I thought that in the `Your name` field I should put my full name (first & last name), not a user name. So I ended up with a username I didn't like.

The change is also consistent with what is used on the other Vector clients:

web

![vector-web-signup](https://cloud.githubusercontent.com/assets/64284/15984079/7221b0ce-2fc6-11e6-857c-94f416238acb.png)

iOS
```
"auth_user_name_placeholder" = "User name";
```
[source link](https://github.com/vector-im/vector-ios/blob/36846071ba4178599bac88ff09159e30191f4264/Vector/Assets/en.lproj/Vector.strings#L50)

Signed-off-by: Thanos Lefteris <your@email.example.org>