### PR TITLE
Improve device notification settings

### DIFF
--- a/vector/src/app/java/im/vector/gcm/GCMHelper.java
+++ b/vector/src/app/java/im/vector/gcm/GCMHelper.java
@@ -29,11 +29,11 @@ public class GCMHelper {
     private static final String LOG_TAG = "GCMHelper";
 
     /**
-     * Retrieve the GCM registration token.
+     * Retrieves the GCM registration token.
      * @param appContext the application context
      * @return the registration token.
      */
-    public static String getRegisrationToken(Context appContext) {
+    public static String getRegistrationToken(Context appContext) {
         String registrationToken;
 
         try {
@@ -46,10 +46,10 @@ public class GCMHelper {
 
             Log.d(LOG_TAG, "GCM Registration Token: " + registrationToken);
         } catch (IOException e) {
-            Log.e(LOG_TAG, "getPushKey failed with exception : " + e.getLocalizedMessage());
+            Log.e(LOG_TAG, "getRegistrationToken failed with exception : " + e.getLocalizedMessage());
             registrationToken = null;
         } catch (Exception e) {
-            Log.e(LOG_TAG, "getPushKey failed with exception : " + e.getLocalizedMessage());
+            Log.e(LOG_TAG, "getRegistrationToken failed with exception : " + e.getLocalizedMessage());
             registrationToken = null;
         }
 

--- a/vector/src/app/java/im/vector/gcm/GCMHelper.java
+++ b/vector/src/app/java/im/vector/gcm/GCMHelper.java
@@ -29,29 +29,30 @@ public class GCMHelper {
     private static final String LOG_TAG = "GCMHelper";
 
     /**
-     * Retrieve the GCM push key (registration token).
+     * Retrieve the GCM registration token.
      * @param appContext the application context
-     * @return the GCM pushKey
+     * @return the registration token.
      */
-    public static String getPushKey(Context appContext) {
-        String pushKey = null;
+    public static String getRegisrationToken(Context appContext) {
+        String registrationToken;
+
         try {
             Log.d(LOG_TAG, "Getting the GCM Registration Token");
 
             InstanceID instanceID = InstanceID.getInstance(appContext);
 
-            pushKey = instanceID.getToken(appContext.getString(R.string.gcm_defaultSenderId),
+            registrationToken = instanceID.getToken(appContext.getString(R.string.gcm_defaultSenderId),
                     GoogleCloudMessaging.INSTANCE_ID_SCOPE, null);
 
-            Log.d(LOG_TAG, "GCM Registration Token: " + pushKey);
+            Log.d(LOG_TAG, "GCM Registration Token: " + registrationToken);
         } catch (IOException e) {
             Log.e(LOG_TAG, "getPushKey failed with exception : " + e.getLocalizedMessage());
-            pushKey = null;
+            registrationToken = null;
         } catch (Exception e) {
             Log.e(LOG_TAG, "getPushKey failed with exception : " + e.getLocalizedMessage());
-            pushKey = null;
+            registrationToken = null;
         }
 
-        return pushKey;
+        return registrationToken;
     }
 }

--- a/vector/src/app/java/im/vector/gcm/MatrixGcmListenerService.java
+++ b/vector/src/app/java/im/vector/gcm/MatrixGcmListenerService.java
@@ -110,7 +110,7 @@ public class MatrixGcmListenerService extends GcmListenerService {
 
                 GcmRegistrationManager gcmManager = Matrix.getInstance(getApplicationContext()).getSharedGcmRegistrationManager();
 
-                if (!gcmManager.isNotificationsAllowed()) {
+                if (!gcmManager.areDeviceNotificationsAllowed()) {
                     Log.d(LOG_TAG, "## onMessageReceived() : the notifications are disabled");
                     return;
                 }

--- a/vector/src/app/java/im/vector/gcm/MatrixGcmListenerService.java
+++ b/vector/src/app/java/im/vector/gcm/MatrixGcmListenerService.java
@@ -108,7 +108,7 @@ public class MatrixGcmListenerService extends GcmListenerService {
                 // update the badge counter
                 CommonActivityUtils.updateBadgeCount(getApplicationContext(), unreadCount);
 
-                GCMRegistrationManager gcmManager = Matrix.getInstance(getApplicationContext()).getSharedGCMRegistrationManager();
+                GcmRegistrationManager gcmManager = Matrix.getInstance(getApplicationContext()).getSharedGCMRegistrationManager();
 
                 if (!gcmManager.areDeviceNotificationsAllowed()) {
                     Log.d(LOG_TAG, "## onMessageReceived() : the notifications are disabled");

--- a/vector/src/app/java/im/vector/gcm/MatrixGcmListenerService.java
+++ b/vector/src/app/java/im/vector/gcm/MatrixGcmListenerService.java
@@ -108,7 +108,7 @@ public class MatrixGcmListenerService extends GcmListenerService {
                 // update the badge counter
                 CommonActivityUtils.updateBadgeCount(getApplicationContext(), unreadCount);
 
-                GcmRegistrationManager gcmManager = Matrix.getInstance(getApplicationContext()).getSharedGcmRegistrationManager();
+                GCMRegistrationManager gcmManager = Matrix.getInstance(getApplicationContext()).getSharedGCMRegistrationManager();
 
                 if (!gcmManager.areDeviceNotificationsAllowed()) {
                     Log.d(LOG_TAG, "## onMessageReceived() : the notifications are disabled");

--- a/vector/src/app/java/im/vector/gcm/MatrixInstanceIDListenerService.java
+++ b/vector/src/app/java/im/vector/gcm/MatrixInstanceIDListenerService.java
@@ -34,6 +34,6 @@ public class MatrixInstanceIDListenerService extends InstanceIDListenerService {
     @Override
     public void onTokenRefresh() {
         Log.d(LOG_TAG, "onTokenRefresh");
-        Matrix.getInstance(this).getSharedGcmRegistrationManager().refreshPushToken(this, null);
+        Matrix.getInstance(this).getSharedGcmRegistrationManager().resetGCMRegistration();
     }
 }

--- a/vector/src/app/java/im/vector/gcm/MatrixInstanceIDListenerService.java
+++ b/vector/src/app/java/im/vector/gcm/MatrixInstanceIDListenerService.java
@@ -34,6 +34,6 @@ public class MatrixInstanceIDListenerService extends InstanceIDListenerService {
     @Override
     public void onTokenRefresh() {
         Log.d(LOG_TAG, "onTokenRefresh");
-        Matrix.getInstance(this).getSharedGcmRegistrationManager().resetGCMRegistration();
+        Matrix.getInstance(this).getSharedGCMRegistrationManager().resetGCMRegistration();
     }
 }

--- a/vector/src/appfdroid/java/im/vector/gcm/GCMHelper.java
+++ b/vector/src/appfdroid/java/im/vector/gcm/GCMHelper.java
@@ -20,11 +20,11 @@ import android.content.Context;
 public class GCMHelper {
 
     /**
-     * Retrieve the GCM registration token.
+     * Retrieves the GCM registration token.
      * @param appContext the application context
      * @return the registration token.
      */
-    public static String getRegisrationToken(Context appContext) {
+    public static String getRegistrationToken(Context appContext) {
         return null;
     }
 }

--- a/vector/src/appfdroid/java/im/vector/gcm/GCMHelper.java
+++ b/vector/src/appfdroid/java/im/vector/gcm/GCMHelper.java
@@ -19,14 +19,12 @@ import android.content.Context;
 
 public class GCMHelper {
 
-    private static final String LOG_TAG = "GCMHelper";
-
     /**
-     * Retrieve the GCM push key.
+     * Retrieve the GCM registration token.
      * @param appContext the application context
-     * @return the GCM pushKey
+     * @return the registration token.
      */
-    public static String getPushKey(Context appContext) {
+    public static String getRegisrationToken(Context appContext) {
         return null;
     }
 }

--- a/vector/src/main/java/im/vector/Matrix.java
+++ b/vector/src/main/java/im/vector/Matrix.java
@@ -48,7 +48,7 @@ import im.vector.activity.CallViewActivity;
 import im.vector.activity.CommonActivityUtils;
 import im.vector.activity.SplashActivity;
 import im.vector.activity.VectorHomeActivity;
-import im.vector.gcm.GcmRegistrationManager;
+import im.vector.gcm.GCMRegistrationManager;
 import im.vector.services.EventStreamService;
 import im.vector.store.LoginStorage;
 import im.vector.util.RageShake;
@@ -76,7 +76,7 @@ public class Matrix {
     private ArrayList<MXSession> mMXSessions;
 
     // GCM registration manager
-    private GcmRegistrationManager mGcmRegistrationManager;
+    private GCMRegistrationManager mGCMRegistrationManager;
 
     // list of store : some sessions or activities use tmp stores
     // provide an storage to exchange them
@@ -110,7 +110,7 @@ public class Matrix {
             // we need to compute the application badge values
 
             if ((null != instance) && (null != instance.mMXSessions) && mRefreshUnreadCounter) {
-                GcmRegistrationManager gcmMgr = instance.getSharedGcmRegistrationManager();
+                GCMRegistrationManager gcmMgr = instance.getSharedGCMRegistrationManager();
 
                 // check if the GCM is not available
                 if ((null != gcmMgr) && (!gcmMgr.useGCM() || !gcmMgr.hasRegistrationToken())) {
@@ -225,9 +225,9 @@ public class Matrix {
     protected Matrix(Context appContext) {
         mAppContext = appContext.getApplicationContext();
         mLoginStorage = new LoginStorage(mAppContext);
-        mMXSessions = new ArrayList<MXSession>();
-        mTmpStores = new ArrayList<IMXStore>();
-        mGcmRegistrationManager = new GcmRegistrationManager(mAppContext);
+        mMXSessions = new ArrayList<>();
+        mTmpStores = new ArrayList<>();
+        mGCMRegistrationManager = new GCMRegistrationManager(mAppContext);
         RageShake.getInstance().start(mAppContext);
 
         mNetworkConnectivityReceiver = new NetworkConnectivityReceiver();
@@ -591,8 +591,11 @@ public class Matrix {
         fromActivity.finish();
     }
 
-    public GcmRegistrationManager getSharedGcmRegistrationManager() {
-        return mGcmRegistrationManager;
+    /**
+     * @return the GCM registration manager
+     */
+    public GCMRegistrationManager getSharedGCMRegistrationManager() {
+        return mGCMRegistrationManager;
     }
 
     //==============================================================================================================

--- a/vector/src/main/java/im/vector/Matrix.java
+++ b/vector/src/main/java/im/vector/Matrix.java
@@ -48,7 +48,7 @@ import im.vector.activity.CallViewActivity;
 import im.vector.activity.CommonActivityUtils;
 import im.vector.activity.SplashActivity;
 import im.vector.activity.VectorHomeActivity;
-import im.vector.gcm.GCMRegistrationManager;
+import im.vector.gcm.GcmRegistrationManager;
 import im.vector.services.EventStreamService;
 import im.vector.store.LoginStorage;
 import im.vector.util.RageShake;
@@ -76,7 +76,7 @@ public class Matrix {
     private ArrayList<MXSession> mMXSessions;
 
     // GCM registration manager
-    private GCMRegistrationManager mGCMRegistrationManager;
+    private GcmRegistrationManager mGCMRegistrationManager;
 
     // list of store : some sessions or activities use tmp stores
     // provide an storage to exchange them
@@ -110,7 +110,7 @@ public class Matrix {
             // we need to compute the application badge values
 
             if ((null != instance) && (null != instance.mMXSessions) && mRefreshUnreadCounter) {
-                GCMRegistrationManager gcmMgr = instance.getSharedGCMRegistrationManager();
+                GcmRegistrationManager gcmMgr = instance.getSharedGCMRegistrationManager();
 
                 // check if the GCM is not available
                 if ((null != gcmMgr) && (!gcmMgr.useGCM() || !gcmMgr.hasRegistrationToken())) {
@@ -234,7 +234,7 @@ public class Matrix {
         mNetworkConnectivityReceiver = new NetworkConnectivityReceiver();
         appContext.registerReceiver(mNetworkConnectivityReceiver, new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION));
 
-        mGCMRegistrationManager = new GCMRegistrationManager(mAppContext);
+        mGCMRegistrationManager = new GcmRegistrationManager(mAppContext);
     }
 
     /**
@@ -597,7 +597,7 @@ public class Matrix {
     /**
      * @return the GCM registration manager
      */
-    public GCMRegistrationManager getSharedGCMRegistrationManager() {
+    public GcmRegistrationManager getSharedGCMRegistrationManager() {
         return mGCMRegistrationManager;
     }
 

--- a/vector/src/main/java/im/vector/Matrix.java
+++ b/vector/src/main/java/im/vector/Matrix.java
@@ -223,15 +223,18 @@ public class Matrix {
 
     // constructor
     protected Matrix(Context appContext) {
+        instance = this;
+
         mAppContext = appContext.getApplicationContext();
         mLoginStorage = new LoginStorage(mAppContext);
         mMXSessions = new ArrayList<>();
         mTmpStores = new ArrayList<>();
-        mGCMRegistrationManager = new GCMRegistrationManager(mAppContext);
         RageShake.getInstance().start(mAppContext);
 
         mNetworkConnectivityReceiver = new NetworkConnectivityReceiver();
         appContext.registerReceiver(mNetworkConnectivityReceiver, new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION));
+
+        mGCMRegistrationManager = new GCMRegistrationManager(mAppContext);
     }
 
     /**

--- a/vector/src/main/java/im/vector/Matrix.java
+++ b/vector/src/main/java/im/vector/Matrix.java
@@ -113,7 +113,7 @@ public class Matrix {
                 GcmRegistrationManager gcmMgr = instance.getSharedGcmRegistrationManager();
 
                 // check if the GCM is not available
-                if ((null != gcmMgr) && (!gcmMgr.useGCM() || !gcmMgr.hasPushKey())) {
+                if ((null != gcmMgr) && (!gcmMgr.useGCM() || !gcmMgr.hasRegistrationToken())) {
                     int unreadCount = 0;
 
                     for(MXSession session :  instance.mMXSessions) {

--- a/vector/src/main/java/im/vector/VectorApp.java
+++ b/vector/src/main/java/im/vector/VectorApp.java
@@ -112,7 +112,7 @@ public class VectorApp extends Application {
         GcmRegistrationManager gcmRegistrationManager = Matrix.getInstance(VectorApp.this).getSharedGcmRegistrationManager();
 
         // suspend the events thread if the client uses GCM
-        if (!gcmRegistrationManager.isBackgroundSyncAllowed() || (gcmRegistrationManager.useGCM() && gcmRegistrationManager.hasPushKey())) {
+        if (!gcmRegistrationManager.isBackgroundSyncAllowed() || (gcmRegistrationManager.useGCM() && gcmRegistrationManager.hasRegistrationToken())) {
             Log.d(LOG_TAG, "suspendApp ; pause the event stream");
             CommonActivityUtils.pauseEventStream(VectorApp.this);
         } else {
@@ -199,7 +199,7 @@ public class VectorApp extends Application {
                 GcmRegistrationManager gcmRegistrationManager = Matrix.getInstance(this).getSharedGcmRegistrationManager();
 
                 if (null != gcmRegistrationManager) {
-                    gcmRegistrationManager.checkPusherRegistration(this);
+                    gcmRegistrationManager.checkRegistrations();
                 }
             }
 

--- a/vector/src/main/java/im/vector/VectorApp.java
+++ b/vector/src/main/java/im/vector/VectorApp.java
@@ -29,7 +29,7 @@ import im.vector.activity.CommonActivityUtils;
 import im.vector.contacts.ContactsManager;
 import im.vector.contacts.PIDsRetriever;
 import im.vector.ga.GAHelper;
-import im.vector.gcm.GcmRegistrationManager;
+import im.vector.gcm.GCMRegistrationManager;
 import im.vector.services.EventStreamService;
 import im.vector.util.LogUtilities;
 
@@ -109,7 +109,7 @@ public class VectorApp extends Application {
      * Suspend background threads.
      */
     private void suspendApp() {
-        GcmRegistrationManager gcmRegistrationManager = Matrix.getInstance(VectorApp.this).getSharedGcmRegistrationManager();
+        GCMRegistrationManager gcmRegistrationManager = Matrix.getInstance(VectorApp.this).getSharedGCMRegistrationManager();
 
         // suspend the events thread if the client uses GCM
         if (!gcmRegistrationManager.isBackgroundSyncAllowed() || (gcmRegistrationManager.useGCM() && gcmRegistrationManager.hasRegistrationToken())) {
@@ -196,7 +196,7 @@ public class VectorApp extends Application {
 
                 // try to perform a GCM registration if it failed
                 // or if the GCM server generated a new push key
-                GcmRegistrationManager gcmRegistrationManager = Matrix.getInstance(this).getSharedGcmRegistrationManager();
+                GCMRegistrationManager gcmRegistrationManager = Matrix.getInstance(this).getSharedGCMRegistrationManager();
 
                 if (null != gcmRegistrationManager) {
                     gcmRegistrationManager.checkRegistrations();

--- a/vector/src/main/java/im/vector/VectorApp.java
+++ b/vector/src/main/java/im/vector/VectorApp.java
@@ -29,7 +29,7 @@ import im.vector.activity.CommonActivityUtils;
 import im.vector.contacts.ContactsManager;
 import im.vector.contacts.PIDsRetriever;
 import im.vector.ga.GAHelper;
-import im.vector.gcm.GCMRegistrationManager;
+import im.vector.gcm.GcmRegistrationManager;
 import im.vector.services.EventStreamService;
 import im.vector.util.LogUtilities;
 
@@ -109,7 +109,7 @@ public class VectorApp extends Application {
      * Suspend background threads.
      */
     private void suspendApp() {
-        GCMRegistrationManager gcmRegistrationManager = Matrix.getInstance(VectorApp.this).getSharedGCMRegistrationManager();
+        GcmRegistrationManager gcmRegistrationManager = Matrix.getInstance(VectorApp.this).getSharedGCMRegistrationManager();
 
         // suspend the events thread if the client uses GCM
         if (!gcmRegistrationManager.isBackgroundSyncAllowed() || (gcmRegistrationManager.useGCM() && gcmRegistrationManager.hasRegistrationToken())) {
@@ -196,7 +196,7 @@ public class VectorApp extends Application {
 
                 // try to perform a GCM registration if it failed
                 // or if the GCM server generated a new push key
-                GCMRegistrationManager gcmRegistrationManager = Matrix.getInstance(this).getSharedGCMRegistrationManager();
+                GcmRegistrationManager gcmRegistrationManager = Matrix.getInstance(this).getSharedGCMRegistrationManager();
 
                 if (null != gcmRegistrationManager) {
                     gcmRegistrationManager.checkRegistrations();

--- a/vector/src/main/java/im/vector/activity/CommonActivityUtils.java
+++ b/vector/src/main/java/im/vector/activity/CommonActivityUtils.java
@@ -162,7 +162,7 @@ public class CommonActivityUtils {
             EventStreamService.removeNotification();
 
             // unregister from the GCM.
-            Matrix.getInstance(activity).getSharedGcmRegistrationManager().unregisterSession(session, null);
+            Matrix.getInstance(activity).getSharedGcmRegistrationManager().unregister(session, null);
 
             // clear credentials
             Matrix.getInstance(activity).clearSession(activity, session, clearCredentials);

--- a/vector/src/main/java/im/vector/activity/CommonActivityUtils.java
+++ b/vector/src/main/java/im/vector/activity/CommonActivityUtils.java
@@ -162,7 +162,7 @@ public class CommonActivityUtils {
             EventStreamService.removeNotification();
 
             // unregister from the GCM.
-            Matrix.getInstance(activity).getSharedGcmRegistrationManager().unregister(session, null);
+            Matrix.getInstance(activity).getSharedGCMRegistrationManager().unregister(session, null);
 
             // clear credentials
             Matrix.getInstance(activity).clearSession(activity, session, clearCredentials);
@@ -333,7 +333,7 @@ public class CommonActivityUtils {
         }
 
         // reset the GCM
-        Matrix.getInstance(activity).getSharedGcmRegistrationManager().reset();
+        Matrix.getInstance(activity).getSharedGCMRegistrationManager().reset();
 
         // clear credentials
         Matrix.getInstance(activity).clearSessions(activity, true);

--- a/vector/src/main/java/im/vector/activity/SplashActivity.java
+++ b/vector/src/main/java/im/vector/activity/SplashActivity.java
@@ -204,10 +204,11 @@ public class SplashActivity extends MXCActionBarActivity {
         mPusherRegistrationComplete = mGcmRegistrationManager.isGCMRegistred();
 
         if (!mPusherRegistrationComplete) {
-            mGcmRegistrationManager.registerPusher(getApplicationContext(), new GcmRegistrationManager.GcmRegistrationIdListener() {
-                @Override
-                public void onPusherRegistered() {
-                    Log.d(LOG_TAG, "The GCM registration is done");
+            mGcmRegistrationManager.registerToGCM(new GcmRegistrationManager.GCMRegistrationListener() {
+                /**
+                 * Common behaviour.
+                 */
+                private void onDone() {
                     SplashActivity.this.runOnUiThread(new Runnable() {
                         @Override
                         public void run() {
@@ -220,22 +221,19 @@ public class SplashActivity extends MXCActionBarActivity {
                 }
 
                 @Override
-                public void onPusherRegistrationFailed() {
+                public void onGCMRegistered() {
+                    Log.d(LOG_TAG, "The GCM registration is done");
+                    onDone();
+                }
+
+                @Override
+                public void onGCMRegistrationFailed() {
                     Log.d(LOG_TAG, "The GCM registration failed");
-
-                    SplashActivity.this.runOnUiThread(new Runnable() {
-                        @Override
-                        public void run() {
-                            CommonActivityUtils.onGcmUpdate(SplashActivity.this);
-                        }
-                    });
-
-                    // can register it ignore
-                    onPusherRegistered();
+                    onDone();
                 }
             });
         } else if (mGcmRegistrationManager.useGCM()) {
-            mGcmRegistrationManager.reregisterSessions(SplashActivity.this, null);
+            mGcmRegistrationManager.forceSessionsRegistration(null);
         }
 
         boolean noUpdate;

--- a/vector/src/main/java/im/vector/activity/SplashActivity.java
+++ b/vector/src/main/java/im/vector/activity/SplashActivity.java
@@ -25,10 +25,9 @@ import org.matrix.androidsdk.listeners.MXEventListener;
 import im.vector.ErrorListener;
 import im.vector.Matrix;
 import im.vector.R;
-import im.vector.gcm.GcmRegistrationManager;
+import im.vector.gcm.GCMRegistrationManager;
 import im.vector.receiver.VectorUniversalLinkReceiver;
 import im.vector.services.EventStreamService;
-import im.vector.util.VectorUtils;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -45,7 +44,7 @@ public class SplashActivity extends MXCActionBarActivity {
     public static final String EXTRA_ROOM_ID = "EXTRA_ROOM_ID";
 
     private Collection<MXSession> mSessions;
-    private GcmRegistrationManager mGcmRegistrationManager;
+    private GCMRegistrationManager mGCMRegistrationManager;
 
     private boolean mInitialSyncComplete = false;
     private boolean mPusherRegistrationComplete = false;
@@ -199,12 +198,11 @@ public class SplashActivity extends MXCActionBarActivity {
             EventStreamService.getInstance().startAccounts(matrixIds);
         }
 
-        mGcmRegistrationManager = Matrix.getInstance(getApplicationContext())
-                .getSharedGcmRegistrationManager();
-        mPusherRegistrationComplete = mGcmRegistrationManager.isGCMRegistred();
+        mGCMRegistrationManager = Matrix.getInstance(getApplicationContext()).getSharedGCMRegistrationManager();
+        mPusherRegistrationComplete = mGCMRegistrationManager.isGCMRegistred();
 
         if (!mPusherRegistrationComplete) {
-            mGcmRegistrationManager.registerToGCM(new GcmRegistrationManager.GCMRegistrationListener() {
+            mGCMRegistrationManager.registerToGCM(new GCMRegistrationManager.GCMRegistrationListener() {
                 /**
                  * Common behaviour.
                  */
@@ -232,8 +230,8 @@ public class SplashActivity extends MXCActionBarActivity {
                     onDone();
                 }
             });
-        } else if (mGcmRegistrationManager.useGCM()) {
-            mGcmRegistrationManager.forceSessionsRegistration(null);
+        } else if (mGCMRegistrationManager.useGCM()) {
+            mGCMRegistrationManager.forceSessionsRegistration(null);
         }
 
         boolean noUpdate;

--- a/vector/src/main/java/im/vector/activity/SplashActivity.java
+++ b/vector/src/main/java/im/vector/activity/SplashActivity.java
@@ -25,7 +25,7 @@ import org.matrix.androidsdk.listeners.MXEventListener;
 import im.vector.ErrorListener;
 import im.vector.Matrix;
 import im.vector.R;
-import im.vector.gcm.GCMRegistrationManager;
+import im.vector.gcm.GcmRegistrationManager;
 import im.vector.receiver.VectorUniversalLinkReceiver;
 import im.vector.services.EventStreamService;
 
@@ -44,7 +44,7 @@ public class SplashActivity extends MXCActionBarActivity {
     public static final String EXTRA_ROOM_ID = "EXTRA_ROOM_ID";
 
     private Collection<MXSession> mSessions;
-    private GCMRegistrationManager mGCMRegistrationManager;
+    private GcmRegistrationManager mGCMRegistrationManager;
 
     private boolean mInitialSyncComplete = false;
     private boolean mPusherRegistrationComplete = false;
@@ -202,7 +202,7 @@ public class SplashActivity extends MXCActionBarActivity {
         mPusherRegistrationComplete = mGCMRegistrationManager.isGCMRegistred();
 
         if (!mPusherRegistrationComplete) {
-            mGCMRegistrationManager.registerToGCM(new GCMRegistrationManager.GCMRegistrationListener() {
+            mGCMRegistrationManager.registerToGCM(new GcmRegistrationManager.GCMRegistrationListener() {
                 /**
                  * Common behaviour.
                  */

--- a/vector/src/main/java/im/vector/fragments/VectorSettingsPreferencesFragment.java
+++ b/vector/src/main/java/im/vector/fragments/VectorSettingsPreferencesFragment.java
@@ -483,7 +483,7 @@ public class VectorSettingsPreferencesFragment extends PreferenceFragment {
                 if (resourceText.equals(getResources().getString(R.string.settings_enable_this_device))) {
                     switchPreference.setChecked(gcmMgr.areDeviceNotificationsAllowed());
                 } else if (resourceText.equals(getResources().getString(R.string.settings_turn_screen_on))) {
-                    switchPreference.setChecked(gcmMgr.turnScreenOn());
+                    switchPreference.setChecked(gcmMgr.isScreenTurnedOn());
                 } else {
                     switchPreference.setEnabled((null != rules) && isConnected);
                     switchPreference.setChecked(preferences.getBoolean(resourceText, false));
@@ -616,7 +616,7 @@ public class VectorSettingsPreferencesFragment extends PreferenceFragment {
         Log.d(LOG_TAG, "onPushRuleClick " + fResourceText + " : set to " + newValue);
 
         if (fResourceText.equals(getResources().getString(R.string.settings_turn_screen_on))) {
-            gcmMgr.setTurnScreenOn(newValue);
+            gcmMgr.setScreenTurnedOn(newValue);
             return;
         }
 

--- a/vector/src/main/java/im/vector/fragments/VectorSettingsPreferencesFragment.java
+++ b/vector/src/main/java/im/vector/fragments/VectorSettingsPreferencesFragment.java
@@ -66,10 +66,9 @@ import java.util.List;
 
 import im.vector.Matrix;
 import im.vector.R;
-import im.vector.VectorApp;
 import im.vector.activity.VectorMediasPickerActivity;
 import im.vector.ga.GAHelper;
-import im.vector.gcm.GcmRegistrationManager;
+import im.vector.gcm.GCMRegistrationManager;
 import im.vector.preference.UserAvatarPreference;
 import im.vector.preference.VectorCustomActionEditTextPreference;
 import im.vector.util.ResourceUtils;
@@ -285,7 +284,7 @@ public class VectorSettingsPreferencesFragment extends PreferenceFragment {
         final SwitchPreference useBackgroundSyncPref = (SwitchPreference)preferenceManager.findPreference(getActivity().getResources().getString(R.string.settings_enable_background_sync));
 
         if (null != useBackgroundSyncPref) {
-            final GcmRegistrationManager gcmMgr = Matrix.getInstance(getActivity()).getSharedGcmRegistrationManager();
+            final GCMRegistrationManager gcmMgr = Matrix.getInstance(getActivity()).getSharedGCMRegistrationManager();
 
             useBackgroundSyncPref.setChecked(gcmMgr.isBackgroundSyncAllowed());
 
@@ -389,7 +388,7 @@ public class VectorSettingsPreferencesFragment extends PreferenceFragment {
                 }
             });
 
-            Matrix.getInstance(getActivity()).getSharedGcmRegistrationManager().refreshPushersList(Matrix.getInstance(getActivity()).getSessions(), new SimpleApiCallback<Void>() {
+            Matrix.getInstance(getActivity()).getSharedGCMRegistrationManager().refreshPushersList(Matrix.getInstance(getActivity()).getSessions(), new SimpleApiCallback<Void>() {
                 @Override
                 public void onSuccess(Void info) {
                     refreshPushersList();
@@ -479,7 +478,7 @@ public class VectorSettingsPreferencesFragment extends PreferenceFragment {
 
             if (null != switchPreference) {
                 if (resourceText.equals(getResources().getString(R.string.settings_enable_this_device))) {
-                    GcmRegistrationManager gcmMgr = Matrix.getInstance(getActivity()).getSharedGcmRegistrationManager();
+                    GCMRegistrationManager gcmMgr = Matrix.getInstance(getActivity()).getSharedGCMRegistrationManager();
                     switchPreference.setChecked(gcmMgr.areDeviceNotificationsAllowed());
                 } else {
                     switchPreference.setEnabled((null != rules) && isConnected);
@@ -609,7 +608,7 @@ public class VectorSettingsPreferencesFragment extends PreferenceFragment {
      */
     private void onPushRuleClick(final String fResourceText, final boolean newValue) {
         if (fResourceText.equals(getResources().getString(R.string.settings_enable_this_device))) {
-            final GcmRegistrationManager gcmMgr = Matrix.getInstance(getActivity()).getSharedGcmRegistrationManager();
+            final GCMRegistrationManager gcmMgr = Matrix.getInstance(getActivity()).getSharedGCMRegistrationManager();
             boolean isConnected = Matrix.getInstance(getActivity()).isConnected();
             final boolean isAllowed = gcmMgr.areDeviceNotificationsAllowed();
 
@@ -619,7 +618,7 @@ public class VectorSettingsPreferencesFragment extends PreferenceFragment {
             // need to register on servers
             if (isConnected && gcmMgr.useGCM() && (gcmMgr.isServerRegistred() || gcmMgr.isServerUnRegistred())) {
 
-                final GcmRegistrationManager.ThirdPartyRegistrationListener listener = new GcmRegistrationManager.ThirdPartyRegistrationListener() {
+                final GCMRegistrationManager.ThirdPartyRegistrationListener listener = new GCMRegistrationManager.ThirdPartyRegistrationListener() {
 
                     private void onDone() {
                         if (null != getActivity()) {
@@ -893,7 +892,7 @@ public class VectorSettingsPreferencesFragment extends PreferenceFragment {
      * Refresh the pushers list
      */
     private void refreshPushersList() {
-        GcmRegistrationManager registrationManager = Matrix.getInstance(getActivity()).getSharedGcmRegistrationManager();
+        GCMRegistrationManager registrationManager = Matrix.getInstance(getActivity()).getSharedGCMRegistrationManager();
         List<Pusher> pushersList = new ArrayList<>(registrationManager.mPushersList);
 
         // check first if there is an update
@@ -1174,7 +1173,7 @@ public class VectorSettingsPreferencesFragment extends PreferenceFragment {
             return;
         }
 
-        final GcmRegistrationManager gcmmgr = Matrix.getInstance(getActivity()).getSharedGcmRegistrationManager();
+        final GCMRegistrationManager gcmmgr = Matrix.getInstance(getActivity()).getSharedGCMRegistrationManager();
 
         final int timeout = gcmmgr.getBackgroundSyncTimeOut() / 1000;
         final int delay = gcmmgr.getBackgroundSyncDelay() / 1000;

--- a/vector/src/main/java/im/vector/fragments/VectorSettingsPreferencesFragment.java
+++ b/vector/src/main/java/im/vector/fragments/VectorSettingsPreferencesFragment.java
@@ -66,7 +66,7 @@ import im.vector.Matrix;
 import im.vector.R;
 import im.vector.activity.VectorMediasPickerActivity;
 import im.vector.ga.GAHelper;
-import im.vector.gcm.GCMRegistrationManager;
+import im.vector.gcm.GcmRegistrationManager;
 import im.vector.preference.UserAvatarPreference;
 import im.vector.preference.VectorCustomActionEditTextPreference;
 import im.vector.util.ResourceUtils;
@@ -285,14 +285,14 @@ public class VectorSettingsPreferencesFragment extends PreferenceFragment {
         final SwitchPreference useBackgroundSyncPref = (SwitchPreference)preferenceManager.findPreference(getActivity().getResources().getString(R.string.settings_enable_background_sync));
 
         if (null != useBackgroundSyncPref) {
-            final GCMRegistrationManager gcmMgr = Matrix.getInstance(getActivity()).getSharedGCMRegistrationManager();
+            final GcmRegistrationManager gcmMgr = Matrix.getInstance(getActivity()).getSharedGCMRegistrationManager();
 
             useBackgroundSyncPref.setChecked(gcmMgr.isBackgroundSyncAllowed());
 
             useBackgroundSyncPref.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
                 @Override
                 public boolean onPreferenceChange(Preference preference, Object newValue) {
-                    gcmMgr.setIsBackgroundSyncAllowed((boolean)newValue);
+                    gcmMgr.setBackgroundSyncAllowed((boolean)newValue);
                     return true;
                 }
             });
@@ -474,7 +474,7 @@ public class VectorSettingsPreferencesFragment extends PreferenceFragment {
 
         BingRuleSet rules = mSession.getDataHandler().pushRules();
 
-        GCMRegistrationManager gcmMgr = Matrix.getInstance(getActivity()).getSharedGCMRegistrationManager();
+        GcmRegistrationManager gcmMgr = Matrix.getInstance(getActivity()).getSharedGCMRegistrationManager();
 
         for(String resourceText : mPushesRuleByResourceId.keySet()) {
             SwitchPreference switchPreference = (SwitchPreference) preferenceManager.findPreference(resourceText);
@@ -483,7 +483,7 @@ public class VectorSettingsPreferencesFragment extends PreferenceFragment {
                 if (resourceText.equals(getResources().getString(R.string.settings_enable_this_device))) {
                     switchPreference.setChecked(gcmMgr.areDeviceNotificationsAllowed());
                 } else if (resourceText.equals(getResources().getString(R.string.settings_turn_screen_on))) {
-                    switchPreference.setChecked(gcmMgr.doNotificationsTurnScreenOn());
+                    switchPreference.setChecked(gcmMgr.turnScreenOn());
                 } else {
                     switchPreference.setEnabled((null != rules) && isConnected);
                     switchPreference.setChecked(preferences.getBoolean(resourceText, false));
@@ -611,12 +611,12 @@ public class VectorSettingsPreferencesFragment extends PreferenceFragment {
      * Update a push rule.
      */
     private void onPushRuleClick(final String fResourceText, final boolean newValue) {
-        final GCMRegistrationManager gcmMgr = Matrix.getInstance(getActivity()).getSharedGCMRegistrationManager();
+        final GcmRegistrationManager gcmMgr = Matrix.getInstance(getActivity()).getSharedGCMRegistrationManager();
 
         Log.d(LOG_TAG, "onPushRuleClick " + fResourceText + " : set to " + newValue);
 
         if (fResourceText.equals(getResources().getString(R.string.settings_turn_screen_on))) {
-            gcmMgr.setNotificationsTurnScreenOn(newValue);
+            gcmMgr.setTurnScreenOn(newValue);
             return;
         }
 
@@ -624,12 +624,12 @@ public class VectorSettingsPreferencesFragment extends PreferenceFragment {
             boolean isConnected = Matrix.getInstance(getActivity()).isConnected();
             final boolean isAllowed = gcmMgr.areDeviceNotificationsAllowed();
 
-            gcmMgr.setAreDeviceNotificationsAllowed(!isAllowed);
+            gcmMgr.setDeviceNotificationsAllowed(!isAllowed);
 
             // when using GCM
             // need to register on servers
             if (isConnected && gcmMgr.useGCM() && (gcmMgr.isServerRegistred() || gcmMgr.isServerUnRegistred())) {
-                final GCMRegistrationManager.ThirdPartyRegistrationListener listener = new GCMRegistrationManager.ThirdPartyRegistrationListener() {
+                final GcmRegistrationManager.ThirdPartyRegistrationListener listener = new GcmRegistrationManager.ThirdPartyRegistrationListener() {
 
                     private void onDone() {
                         if (null != getActivity()) {
@@ -650,7 +650,7 @@ public class VectorSettingsPreferencesFragment extends PreferenceFragment {
 
                     @Override
                     public void onThirdPartyRegistrationFailed() {
-                        gcmMgr.setAreDeviceNotificationsAllowed(isAllowed);
+                        gcmMgr.setDeviceNotificationsAllowed(isAllowed);
                         onDone();
                     }
 
@@ -661,7 +661,7 @@ public class VectorSettingsPreferencesFragment extends PreferenceFragment {
 
                     @Override
                     public void onThirdPartyUnregistrationFailed() {
-                        gcmMgr.setAreDeviceNotificationsAllowed(isAllowed);
+                        gcmMgr.setDeviceNotificationsAllowed(isAllowed);
                         onDone();
                     }
                 };
@@ -903,7 +903,7 @@ public class VectorSettingsPreferencesFragment extends PreferenceFragment {
      * Refresh the pushers list
      */
     private void refreshPushersList() {
-        GCMRegistrationManager registrationManager = Matrix.getInstance(getActivity()).getSharedGCMRegistrationManager();
+        GcmRegistrationManager registrationManager = Matrix.getInstance(getActivity()).getSharedGCMRegistrationManager();
         List<Pusher> pushersList = new ArrayList<>(registrationManager.mPushersList);
 
         // check first if there is an update
@@ -1184,7 +1184,7 @@ public class VectorSettingsPreferencesFragment extends PreferenceFragment {
             return;
         }
 
-        final GCMRegistrationManager gcmmgr = Matrix.getInstance(getActivity()).getSharedGCMRegistrationManager();
+        final GcmRegistrationManager gcmmgr = Matrix.getInstance(getActivity()).getSharedGCMRegistrationManager();
 
         final int timeout = gcmmgr.getBackgroundSyncTimeOut() / 1000;
         final int delay = gcmmgr.getBackgroundSyncDelay() / 1000;

--- a/vector/src/main/java/im/vector/gcm/GcmRegistrationManager.java
+++ b/vector/src/main/java/im/vector/gcm/GcmRegistrationManager.java
@@ -58,7 +58,6 @@ public final class GCMRegistrationManager {
     private static final String PREFS_PUSHER_FILE_TAG_KEY = "GcmRegistrationManager.pusherFileTag";
     private static final String PREFS_ALLOW_NOTIFICATIONS = "GcmRegistrationManager.PREFS_ALLOW_NOTIFICATIONS";
     private static final String PREFS_TURN_SCREEN_ON = "GcmRegistrationManager.PREFS_TURN_SCREEN_ON";
-    private static final String PREFS_KEEP_NOTIFS_WITH_SOUND = "GcmRegistrationManager.PREFS_KEEP_NOTIFS_WITH_SOUND";
     private static final String PREFS_ALLOW_BACKGROUND_SYNC = "GcmRegistrationManager.PREFS_ALLOW_BACKGROUND_SYNC";
 
     private static final String PREFS_SYNC_TIMEOUT = "GcmRegistrationManager.PREFS_SYNC_TIMEOUT";
@@ -172,6 +171,8 @@ public final class GCMRegistrationManager {
      * reset the Registration
      */
     public void reset() {
+        Log.d(LOG_TAG, "Reset the registration");
+
         // unregister
         unregister(null);
 
@@ -190,6 +191,8 @@ public final class GCMRegistrationManager {
      * The GCM could have cleared it (onTokenRefresh).
      */
     public void checkRegistrations() {
+        Log.d(LOG_TAG, "checkRegistrations with state " + mRegistrationState);
+
         if (!useGCM()) {
             Log.d(LOG_TAG, "checkPusherRegistration : GCM is disabled");
             return;
@@ -244,6 +247,8 @@ public final class GCMRegistrationManager {
      * @param gcmRegistrationListener the events listener.
      */
     public void registerToGCM(final GCMRegistrationListener gcmRegistrationListener) {
+        Log.d(LOG_TAG, "registerToGCM with state " + mRegistrationState);
+
         // do not use GCM
         if (!useGCM()) {
             Log.d(LOG_TAG, "registerPusher : GCM is disabled");
@@ -361,8 +366,8 @@ public final class GCMRegistrationManager {
      * @param session the session
      * @return the profile tag
      */
-    private String computePushTag(final MXSession session) {
-        String tag =  DEFAULT_PUSHER_FILE_TAG + "_" + Math.abs(session.getMyUserId().hashCode());
+    private static String computePushTag(final MXSession session) {
+        String tag = DEFAULT_PUSHER_FILE_TAG + "_" + Math.abs(session.getMyUserId().hashCode());
 
         // tag max length : 32 bytes
         if (tag.length() > 32) {
@@ -396,6 +401,8 @@ public final class GCMRegistrationManager {
 
             return;
         }
+
+        Log.d(LOG_TAG, "registerToThirdPartyServer of " + session.getMyUserId());
 
         session.getPushersRestClient()
                 .addHttpPusher(mRegistrationToken, DEFAULT_PUSHER_APP_ID, computePushTag(session),
@@ -510,6 +517,8 @@ public final class GCMRegistrationManager {
      * @param listener the registration listener.
      */
     public void register(final ThirdPartyRegistrationListener listener) {
+        Log.d(LOG_TAG, "register with state " + mRegistrationState);
+
         addSessionsRegistrationListener(listener);
 
         if (mRegistrationState == RegistrationState.SERVER_REGISTRATING) {
@@ -605,6 +614,8 @@ public final class GCMRegistrationManager {
      * @param listener the registration listener.
      */
     public void unregister(final ThirdPartyRegistrationListener listener) {
+        Log.d(LOG_TAG, "unregister with state " + mRegistrationState);
+
         addSessionsRegistrationListener(listener);
 
         if (mRegistrationState == RegistrationState.SERVER_UNREGISTRATING) {
@@ -667,6 +678,8 @@ public final class GCMRegistrationManager {
      * @param listener the lisneter
      */
     public void unregister(final MXSession session, final ThirdPartyRegistrationListener listener) {
+        Log.d(LOG_TAG, "unregister " + session.getMyUserId());
+
         session.getPushersRestClient()
                 .removeHttpPusher(mRegistrationToken, DEFAULT_PUSHER_APP_ID, computePushTag(session),
                         mPusherLang, mPusherAppName, mBasePusherDeviceName,
@@ -816,23 +829,6 @@ public final class GCMRegistrationManager {
     public void setNotificationsTurnScreenOn(boolean flag) {
         getSharedPreferences().edit()
                 .putBoolean(PREFS_TURN_SCREEN_ON, flag)
-                .apply();
-    }
-
-    /**
-     * @return true if a new notification does not have sound and the current displayed one has.
-     */
-    public boolean preferNotificationWithSound() {
-        return getSharedPreferences().getBoolean(PREFS_KEEP_NOTIFS_WITH_SOUND, false);
-    }
-
-    /**
-     * Update the notificatioon with sound preference
-     * @param flag true to prefer notification with sound.
-     */
-    public void setPreferNotificationWithSound(boolean flag) {
-        getSharedPreferences().edit()
-                .putBoolean(PREFS_KEEP_NOTIFS_WITH_SOUND, flag)
                 .apply();
     }
 

--- a/vector/src/main/java/im/vector/gcm/GcmRegistrationManager.java
+++ b/vector/src/main/java/im/vector/gcm/GcmRegistrationManager.java
@@ -46,7 +46,7 @@ import java.util.List;
 /**
  * Helper class to store the GCM registration ID in {@link SharedPreferences}
  */
-public final class GcmRegistrationManager {
+public final class GCMRegistrationManager {
     private static final String LOG_TAG = "GcmRegistrationManager";
 
     private static final String PREFS_GCM = "GcmRegistrationManager";
@@ -136,7 +136,7 @@ public final class GcmRegistrationManager {
      * Constructor
      * @param appContext the application context.
      */
-    public GcmRegistrationManager(final Context appContext) {
+    public GCMRegistrationManager(final Context appContext) {
         mContext = appContext.getApplicationContext();
 
         try {

--- a/vector/src/main/java/im/vector/gcm/GcmRegistrationManager.java
+++ b/vector/src/main/java/im/vector/gcm/GcmRegistrationManager.java
@@ -804,7 +804,7 @@ public final class GcmRegistrationManager {
     /**
      * @return true if the notifications should turn the screen on for 3 seconds.
      */
-    public boolean turnScreenOn() {
+    public boolean isScreenTurnedOn() {
         return getGcmSharedPreferences().getBoolean(PREFS_TURN_SCREEN_ON, false);
     }
 
@@ -812,7 +812,7 @@ public final class GcmRegistrationManager {
      * Update the screen on management when a notification is received.
      * @param flag true to enable the device notifications.
      */
-    public void setTurnScreenOn(boolean flag) {
+    public void setScreenTurnedOn(boolean flag) {
         getGcmSharedPreferences().edit()
                 .putBoolean(PREFS_TURN_SCREEN_ON, flag)
                 .apply();

--- a/vector/src/main/java/im/vector/gcm/GcmRegistrationManager.java
+++ b/vector/src/main/java/im/vector/gcm/GcmRegistrationManager.java
@@ -22,11 +22,13 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.AsyncTask;
 import android.os.Build;
+import android.os.SystemClock;
 import android.text.TextUtils;
 import android.util.Log;
 
 import org.matrix.androidsdk.MXSession;
 import org.matrix.androidsdk.data.Pusher;
+import org.matrix.androidsdk.listeners.IMXNetworkEventListener;
 import org.matrix.androidsdk.rest.callback.ApiCallback;
 import org.matrix.androidsdk.rest.model.MatrixError;
 import org.matrix.androidsdk.rest.model.PushersResponse;
@@ -45,56 +47,67 @@ import java.util.List;
  * Helper class to store the GCM registration ID in {@link SharedPreferences}
  */
 public final class GcmRegistrationManager {
-    private static String LOG_TAG = "GcmRegistrationManager";
+    private static final String LOG_TAG = "GcmRegistrationManager";
 
-    public static final String PREFS_GCM = "GcmRegistrationManager";
-    public static final String PREFS_KEY_REG_ID_PREFIX = "REG_ID-";
+    private static final String PREFS_GCM = "GcmRegistrationManager";
+    private static final String PREFS_KEY_REG_ID_PREFIX = "REG_ID-";
 
-    public static final String PREFS_PUSHER_APP_ID_KEY = "GcmRegistrationManager.pusherAppId";
-    public static final String PREFS_SENDER_ID_KEY = "GcmRegistrationManager.senderId";
-    public static final String PREFS_PUSHER_URL_KEY = "GcmRegistrationManager.pusherUrl";
-    public static final String PREFS_PUSHER_FILE_TAG_KEY = "GcmRegistrationManager.pusherFileTag";
-    public static final String PREFS_ALLOW_NOTIFICATIONS = "GcmRegistrationManager.PREFS_ALLOW_NOTIFICATIONS";
-    public static final String PREFS_ALLOW_BACKGROUND_SYNC = "GcmRegistrationManager.PREFS_ALLOW_BACKGROUND_SYNC";
+    private static final String PREFS_PUSHER_APP_ID_KEY = "GcmRegistrationManager.pusherAppId";
+    private static final String PREFS_SENDER_ID_KEY = "GcmRegistrationManager.senderId";
+    private static final String PREFS_PUSHER_URL_KEY = "GcmRegistrationManager.pusherUrl";
+    private static final String PREFS_PUSHER_FILE_TAG_KEY = "GcmRegistrationManager.pusherFileTag";
+    private static final String PREFS_ALLOW_NOTIFICATIONS = "GcmRegistrationManager.PREFS_ALLOW_NOTIFICATIONS";
+    private static final String PREFS_TURN_SCREEN_ON = "GcmRegistrationManager.PREFS_TURN_SCREEN_ON";
+    private static final String PREFS_KEEP_NOTIFS_WITH_SOUND = "GcmRegistrationManager.PREFS_KEEP_NOTIFS_WITH_SOUND";
+    private static final String PREFS_ALLOW_BACKGROUND_SYNC = "GcmRegistrationManager.PREFS_ALLOW_BACKGROUND_SYNC";
 
-    public static final String PREFS_SYNC_TIMEOUT = "GcmRegistrationManager.PREFS_SYNC_TIMEOUT";
-    public static final String PREFS_SYNC_DELAY = "GcmRegistrationManager.PREFS_SYNC_DELAY";
+    private static final String PREFS_SYNC_TIMEOUT = "GcmRegistrationManager.PREFS_SYNC_TIMEOUT";
+    private static final String PREFS_SYNC_DELAY = "GcmRegistrationManager.PREFS_SYNC_DELAY";
 
-    private static String DEFAULT_PUSHER_APP_ID = "im.vector.app.android";
-    private static String DEFAULT_PUSHER_URL = "https://matrix.org/_matrix/push/v1/notify";
-    private static String DEFAULT_PUSHER_FILE_TAG = "mobile";
+    private static final String DEFAULT_PUSHER_APP_ID = "im.vector.app.android";
+    private static final String DEFAULT_PUSHER_URL = "https://matrix.org/_matrix/push/v1/notify";
+    private static final String DEFAULT_PUSHER_FILE_TAG = "mobile";
 
     /**
      * GCM registration interface
      */
-    public interface GcmRegistrationIdListener {
-        void onPusherRegistered();
-        void onPusherRegistrationFailed();
+    public interface GCMRegistrationListener {
+        // GCM is properly registered.
+        void onGCMRegistered();
+        // GCM registration fails.
+        void onGCMRegistrationFailed();
     }
 
     /**
-     * 3rd party server registation interface
+     * 3rd party server registration interface
      */
-    public interface GcmSessionRegistration {
-        void onSessionRegistred();
-        void onSessionRegistrationFailed();
+    public interface ThirdPartyRegistrationListener {
+        // the third party server is registered
+        void onThirdPartyRegistered();
+        // the third party server registration fails.
+        void onThirdPartyRegistrationFailed();
 
-        void onSessionUnregistred();
-        void onSessionUnregistrationFailed();
+        // the third party server is unregister
+        void onThirdPartyUnregistered();
+        // the third party server unregistration fails
+        void onThirdPartyUnregistrationFailed();
     }
-
-    // theses both entries can be updated from the settings page in debug mode
-    private String mPusherAppId = null;
-    private String mPusherUrl = null;
-    private String mPusherBaseFileTag = null;
 
     private String mPusherAppName = null;
     private String mPusherLang = null;
-    private ArrayList<GcmSessionRegistration> mSessionsregistrationListener = new ArrayList<GcmSessionRegistration>();
+
+    //
+    private String mRegistrationTokenPreferenceKey = null;
+
+    // the session registration listener
+    private final ArrayList<ThirdPartyRegistrationListener> mThirdPartyRegistrationListeners = new ArrayList<>();
 
     // the pushers list
     public ArrayList<Pusher> mPushersList = new ArrayList<>();
 
+    /**
+     * Registration steps
+     */
     private enum RegistrationState {
         UNREGISTRATED,
         GCM_REGISTRATING,
@@ -104,40 +117,63 @@ public final class GcmRegistrationManager {
         SERVER_UNREGISTRATING,
     }
 
-    private static String mBasePusherDeviceName = Build.MODEL.trim();
+    // the pusher base
+    private static final String mBasePusherDeviceName = Build.MODEL.trim();
 
-    private Context mContext;
+    // the context
+    private final Context mContext;
+
+    // the registration state
     private RegistrationState mRegistrationState = RegistrationState.UNREGISTRATED;
 
-    private String mPushKey = null;
+    // defines the GCM registration token
+    private String mRegistrationToken = null;
 
+    // 3 states : null not initialized (retrieved by flavor)
     private static Boolean mUseGCM;
 
     /**
      * Constructor
      * @param appContext the application context.
      */
-    public GcmRegistrationManager(Context appContext) {
+    public GcmRegistrationManager(final Context appContext) {
         mContext = appContext.getApplicationContext();
 
         try {
             PackageInfo pInfo = mContext.getPackageManager().getPackageInfo(mContext.getPackageName(), 0);
             mPusherAppName = pInfo.packageName;
             mPusherLang = mContext.getResources().getConfiguration().locale.getLanguage();
+            mRegistrationTokenPreferenceKey = PREFS_KEY_REG_ID_PREFIX + Integer.toString(pInfo.versionCode);
         } catch (Exception e) {
             mPusherAppName = "VectorApp";
             mPusherLang = "en";
+            mRegistrationTokenPreferenceKey = PREFS_KEY_REG_ID_PREFIX + System.currentTimeMillis();
         }
 
-        loadGcmData();
+        Matrix.getInstance(appContext).addNetworkEventListener(new IMXNetworkEventListener() {
+            @Override
+            public void onNetworkConnectionUpdate(boolean isConnected) {
+                if (isConnected) {
+                    // test if the server registration / unregistration should be done
+                    if (useGCM()) {
+                        // test if the user expect having notifications on his device but it was not yet done
+                        if (areDeviceNotificationsAllowed() && (mRegistrationState == RegistrationState.GCM_REGISTRED)) {
+                            register(null);
+                        } else if (!areDeviceNotificationsAllowed() && (mRegistrationState == RegistrationState.SERVER_REGISTERED)) {
+                            unregister(null);
+                        }
+                    }
+                }
+            }
+        });
     }
 
     /**
      * reset the Registration
      */
     public void reset() {
-
-        unregisterSessions(null);
+        // unregister
+        unregister(null);
 
         // remove the customized keys
         getSharedPreferences().
@@ -147,18 +183,277 @@ public final class GcmRegistrationManager {
                 remove(PREFS_PUSHER_URL_KEY).
                 remove(PREFS_PUSHER_FILE_TAG_KEY).
                 commit();
-
-        loadGcmData();
     }
 
     /**
-     * Refresh the pushers list
+     * Check if the GCM registration has been broken with a new token ID.
+     * The GCM could have cleared it (onTokenRefresh).
+     */
+    public void checkRegistrations() {
+        if (!useGCM()) {
+            Log.d(LOG_TAG, "checkPusherRegistration : GCM is disabled");
+            return;
+        }
+
+        if (mRegistrationState == RegistrationState.UNREGISTRATED) {
+            Log.d(LOG_TAG, "checkPusherRegistration : try to register to GCM server");
+
+            registerToGCM(new GCMRegistrationListener() {
+                @Override
+                public void onGCMRegistered() {
+                    Log.d(LOG_TAG, "checkPusherRegistration : reregistered");
+                    CommonActivityUtils.onGcmUpdate(mContext);
+                }
+
+                @Override
+                public void onGCMRegistrationFailed() {
+                    Log.d(LOG_TAG, "checkPusherRegistration : onPusherRegistrationFailed");
+                }
+            });
+        } else if (mRegistrationState == RegistrationState.GCM_REGISTRED) {
+            // register the 3rd party server
+            // the server registration might have failed
+            // so ensure that it will be done when the application is debackgrounded.
+            if (useGCM() && areDeviceNotificationsAllowed()) {
+                registerToGCM(null);
+            }
+        } else if (mRegistrationState == RegistrationState.SERVER_REGISTERED) {
+            refreshPushersList(new ArrayList<>(Matrix.getInstance(mContext).getSessions()), null);
+        }
+    }
+
+    //================================================================================
+    // GCM registration
+    //================================================================================
+
+    /**
+     * Retrieve the GCM registration token.
+     * @return the GCM registration token
+     */
+    private String getGCMRegistrationToken() {
+        String registrationToken = getStoredRegistrationToken();
+
+        if (registrationToken == null) {
+            registrationToken = GCMHelper.getRegisrationToken(mContext);
+        }
+        return registrationToken;
+    }
+
+    /**
+     * Register to GCM.
+     * @param gcmRegistrationListener the events listener.
+     */
+    public void registerToGCM(final GCMRegistrationListener gcmRegistrationListener) {
+        // do not use GCM
+        if (!useGCM()) {
+            Log.d(LOG_TAG, "registerPusher : GCM is disabled");
+
+            // warn the listener
+            if (null != gcmRegistrationListener) {
+                try {
+                    gcmRegistrationListener.onGCMRegistrationFailed();
+                } catch (Exception e) {
+                    Log.e(LOG_TAG, "registerPusher : onPusherRegistered/onPusherRegistrationFailed failed " + e.getLocalizedMessage());
+                }
+            }
+            return;
+        }
+
+        // already register
+        if (mRegistrationState == RegistrationState.GCM_REGISTRED) {
+            if (null != gcmRegistrationListener) {
+                gcmRegistrationListener.onGCMRegistered();
+            }
+        } else if (mRegistrationState != RegistrationState.UNREGISTRATED) {
+            if (null != gcmRegistrationListener) {
+                gcmRegistrationListener.onGCMRegistrationFailed();
+            }
+        } else {
+            mRegistrationState = RegistrationState.GCM_REGISTRATING;
+
+            new AsyncTask<Void, Void, String>() {
+                @Override
+                protected String doInBackground(Void... voids) {
+                    String registrationToken = getGCMRegistrationToken();
+
+                    if (registrationToken != null) {
+                        mRegistrationToken = registrationToken;
+                    }
+
+                    return registrationToken;
+                }
+
+                @Override
+                protected void onPostExecute(String pushKey) {
+                    mRegistrationState = (pushKey != null) ? RegistrationState.GCM_REGISTRED : RegistrationState.UNREGISTRATED;
+                    setStoredRegistrationToken(pushKey);
+
+                    // warn the listener
+                    if (null != gcmRegistrationListener) {
+                        try {
+                            if (pushKey != null) {
+                                gcmRegistrationListener.onGCMRegistered();
+                            } else {
+                                gcmRegistrationListener.onGCMRegistrationFailed();
+                            }
+                        } catch (Exception e) {
+                            Log.e(LOG_TAG, "registerPusher : onPusherRegistered/onPusherRegistrationFailed failed " + e.getLocalizedMessage());
+                        }
+                    }
+
+                    if (mRegistrationState == RegistrationState.GCM_REGISTRED) {
+                        // register the sessions to the 3rd party server
+                        // this setting should be updated from the listener
+                        if (useGCM()) {
+                            register(null);
+                        }
+                    }
+                }
+            }.execute();
+        }
+    }
+
+    /**
+     * Reset the GCM registration (happen when the registration token has been updated).
+     */
+    public void resetGCMRegistration() {
+        Log.d(LOG_TAG, "resetGCMRegistration");
+
+        if (RegistrationState.SERVER_REGISTERED == mRegistrationState) {
+            Log.d(LOG_TAG, "resetGCMRegistration : unregister before retrieving the new GCM key");
+
+            unregister(new ThirdPartyRegistrationListener() {
+                @Override
+                public void onThirdPartyRegistered() {
+                }
+
+                @Override
+                public void onThirdPartyRegistrationFailed() {
+                }
+
+                @Override
+                public void onThirdPartyUnregistered() {
+                    Log.d(LOG_TAG, "resetGCMRegistration : unregistration is done --> start the registration process");
+                    resetGCMRegistration();
+                }
+
+                @Override
+                public void onThirdPartyUnregistrationFailed() {
+                    Log.d(LOG_TAG, "resetGCMRegistration : unregistration failed.");
+                }
+            });
+
+        } else {
+            Log.d(LOG_TAG, "resetGCMRegistration : make a full registration process.");
+
+            setStoredRegistrationToken(null);
+            mRegistrationState = RegistrationState.UNREGISTRATED;
+            register(null);
+        }
+    }
+
+    //================================================================================
+    // third party registration management
+    //================================================================================
+
+    /**
+     * Compute the profileTag for a session
+     * @param session the session
+     * @return the profile tag
+     */
+    private String computePushTag(final MXSession session) {
+        String tag =  DEFAULT_PUSHER_FILE_TAG + "_" + Math.abs(session.getMyUserId().hashCode());
+
+        // tag max length : 32 bytes
+        if (tag.length() > 32) {
+            tag = Math.abs(tag.hashCode()) + "";
+        }
+
+        return tag;
+    }
+
+    /**
+     * Register the session to the 3rd-party app server
+     * @param session the session to register.
+     * @param listener the registration listener
+     */
+    private void registerToThirdPartyServer(final MXSession session, boolean append, final ThirdPartyRegistrationListener listener) {
+        // test if the push server registration is allowed
+        if (!areDeviceNotificationsAllowed() || !useGCM()) {
+            if (!areDeviceNotificationsAllowed()) {
+                Log.d(LOG_TAG, "registerPusher : the user disabled it.");
+            }  else {
+                Log.d(LOG_TAG, "registerPusher : GCM is disabled.");
+            }
+
+            if (null != listener) {
+                try {
+                    listener.onThirdPartyRegistrationFailed();
+                }  catch (Exception e) {
+                    Log.e(LOG_TAG, "registerToThirdPartyServer failed " + e.getLocalizedMessage());
+                }
+            }
+
+            return;
+        }
+
+        session.getPushersRestClient()
+                .addHttpPusher(mRegistrationToken, DEFAULT_PUSHER_APP_ID, computePushTag(session),
+                        mPusherLang, mPusherAppName, mBasePusherDeviceName,
+                        DEFAULT_PUSHER_URL, append, new ApiCallback<Void>() {
+                            @Override
+                            public void onSuccess(Void info) {
+                                Log.d(LOG_TAG, "registerPusher succeeded");
+
+                                if (null != listener) {
+                                    try {
+                                        listener.onThirdPartyRegistered();
+                                    } catch (Exception e) {
+                                        Log.e(LOG_TAG, "onSessionRegistered failed " + e.getLocalizedMessage());
+                                    }
+                                }
+                            }
+
+                            private void onError(final String message) {
+                                Log.e(LOG_TAG, "fail to register " + session.getMyUserId() + " (" + message + ")");
+
+                                if (null != listener) {
+                                    try {
+                                        listener.onThirdPartyRegistrationFailed();
+                                    } catch (Exception e) {
+                                    }
+                                }
+                            }
+
+                            @Override
+                            public void onNetworkError(Exception e) {
+                                Log.e(LOG_TAG, "registerPusher onNetworkError " + e.getMessage());
+                                onError(e.getLocalizedMessage());
+                            }
+
+                            @Override
+                            public void onMatrixError(MatrixError e) {
+                                Log.e(LOG_TAG, "registerPusher onMatrixError " + e.errcode);
+                                onError(e.getLocalizedMessage());
+                            }
+
+                            @Override
+                            public void onUnexpectedError(Exception e) {
+                                Log.e(LOG_TAG, "registerPusher onUnexpectedError " + e.getMessage());
+                                onError(e.getLocalizedMessage());
+                            }
+                        });
+    }
+
+    /**
+     * Refresh the pushers list (i.e the devices which expect to have notification).
      * @param sessions the sessions
      * @param callback the callback;
      */
     public void refreshPushersList(List<MXSession> sessions, final ApiCallback<Void> callback) {
         if ((null != sessions) && (sessions.size() > 0)) {
             sessions.get(0).getPushersRestClient().getPushers(new ApiCallback<PushersResponse>() {
+
                 @Override
                 public void onSuccess(PushersResponse pushersResponse) {
                     if (null == pushersResponse.pushers) {
@@ -191,129 +486,287 @@ public final class GcmRegistrationManager {
     }
 
     /**
-     * Force to retrieve the
-     * @param appContext
-     * @param registrationListener
+     * Force to register the sessions to the third party servers.
+     * The GCM registration must have been done and there is no pending registration.
+     * @param listener the listener
      */
-    public void refreshPushToken(final Context appContext, final GcmRegistrationIdListener registrationListener) {
-        setStoredPushKey(null);
-        mRegistrationState = RegistrationState.UNREGISTRATED;
-        registerPusher(appContext, registrationListener);
+    public void forceSessionsRegistration(final ThirdPartyRegistrationListener listener) {
+        if ((mRegistrationState == RegistrationState.SERVER_REGISTERED) || (mRegistrationState == RegistrationState.GCM_REGISTRED)){
+            mRegistrationState = RegistrationState.GCM_REGISTRED;
+
+            register(listener);
+        } else {
+            if (null != listener) {
+                try {
+                    listener.onThirdPartyRegistrationFailed();
+                } catch (Exception e) {
+                }
+            }
+        }
     }
 
     /**
-     * Check if the GCM registration has been broken with a new token ID.
-     * The GCM could have resetted it (onTokenRefresh).
-     * @param appContext the application context
+     * Register the current sessions to the 3rd party GCM server
+     * @param listener the registration listener.
      */
-    public void checkPusherRegistration(final Context appContext) {
-        if (!useGCM()) {
-            Log.d(LOG_TAG, "checkPusherRegistration : GCM is disabled");
-            return;
-        }
+    public void register(final ThirdPartyRegistrationListener listener) {
+        addSessionsRegistrationListener(listener);
 
-        if (mRegistrationState == RegistrationState.UNREGISTRATED) {
-            Log.d(LOG_TAG, "checkPusherRegistration : try to register to GCM server");
+        if (mRegistrationState == RegistrationState.SERVER_REGISTRATING) {
+            // please wait
+        } else if (mRegistrationState == RegistrationState.UNREGISTRATED) {
+            Log.d(LOG_TAG, "registerSessions unregistrated : try to register again");
 
-            registerPusher(appContext, new GcmRegistrationIdListener() {
+            // if the registration failed
+            // try to register again
+            registerToGCM(new GCMRegistrationListener() {
                 @Override
-                public void onPusherRegistered() {
-                    Log.d(LOG_TAG, "checkPusherRegistration : reregistered");
-                    CommonActivityUtils.onGcmUpdate(mContext);
+                public void onGCMRegistered() {
+                    Log.d(LOG_TAG, "GCM registration failed again : register on server side");
+                    register(listener);
                 }
 
                 @Override
-                public void onPusherRegistrationFailed() {
-                    Log.d(LOG_TAG, "checkPusherRegistration : onPusherRegistrationFailed");
+                public void onGCMRegistrationFailed() {
+                    Log.d(LOG_TAG, "registerSessions unregistrated : GCM registration failed again");
+                    onThirdPartyRegistrationFailed();
                 }
             });
-        } else if (mRegistrationState == RegistrationState.GCM_REGISTRED) {
-            // register the 3rd party server
-            // the server registration might have failed
-            // so ensure that it will be done when the application is debackgrounded.
-            if (useGCM()) {
-                registerSessions(appContext, null);
-            }
         } else if (mRegistrationState == RegistrationState.SERVER_REGISTERED) {
-            refreshPushersList(new ArrayList<MXSession>(Matrix.getInstance(mContext).getSessions()), null);
+            Log.e(LOG_TAG, "registerSessions : already registred");
+            onThirdPartyRegistered();
+        } else if (mRegistrationState != RegistrationState.GCM_REGISTRED) {
+            Log.e(LOG_TAG, "registerSessions : invalid state " + mRegistrationState);
+            onThirdPartyRegistrationFailed();
+        } else {
+            // check if the notifications must be displayed
+            if (useGCM() && areDeviceNotificationsAllowed()) {
+                mRegistrationState = RegistrationState.SERVER_REGISTRATING;
+                registerToThirdPartyServer(new ArrayList<>(Matrix.getInstance(mContext).getSessions()), 0);
+            } else {
+                onThirdPartyRegistrationFailed();
+            }
         }
     }
 
     /**
-     * Register to the GCM.
-     * @param registrationListener the events listener.
+     * Recursive method to register a MXSessions list.
+     * @param sessions the sessions list.
+     * @param index the index of the MX sessions to register.
      */
-    public void registerPusher(final Context appContext, final GcmRegistrationIdListener registrationListener) {
-        // do not use GCM
-        if (!useGCM()) {
-            Log.d(LOG_TAG, "registerPusher : GCM is disabled");
+    private void registerToThirdPartyServer(final ArrayList<MXSession> sessions, final int index) {
+        // reach this end of the list ?
+        if (index >= sessions.size()) {
+            Log.d(LOG_TAG, "registerSessions : all the sessions are registered");
+            mRegistrationState = RegistrationState.SERVER_REGISTERED;
+            onThirdPartyRegistered();
 
-            mPusherAppId = mPusherUrl = mPusherBaseFileTag = null;
+            // get the pushers list
+            refreshPushersList(sessions, null);
 
-            // warn the listener
-            if (null != registrationListener) {
-                try {
-                    registrationListener.onPusherRegistrationFailed();
-                } catch (Exception e) {
-                    Log.e(LOG_TAG, "registerPusher : onPusherRegistered/onPusherRegistrationFailed failed " + e.getLocalizedMessage());
-                }
+            // the notifications have been disabled while registering them
+            if (useGCM() && !areDeviceNotificationsAllowed()) {
+                // remove them
+                unregister(null);
             }
+
             return;
         }
 
-        // already registred
-        if (mRegistrationState == RegistrationState.GCM_REGISTRED) {
-            if (null != registrationListener) {
-                registrationListener.onPusherRegistered();
+        final MXSession session = sessions.get(index);
+
+        registerToThirdPartyServer(session, (index > 0), new ThirdPartyRegistrationListener() {
+            @Override
+            public void onThirdPartyRegistered() {
+                Log.d(LOG_TAG, "registerSessions : session " + session.getMyUserId() + " is registred");
+                registerToThirdPartyServer(sessions, index + 1);
             }
-        } else if (mRegistrationState != RegistrationState.UNREGISTRATED) {
-            if (null != registrationListener) {
-                registrationListener.onPusherRegistrationFailed();
+
+            @Override
+            public void onThirdPartyRegistrationFailed() {
+                Log.d(LOG_TAG, "registerSessions : onSessionRegistrationFailed " + session.getMyUserId());
+
+                mRegistrationState = RegistrationState.GCM_REGISTRED;
+                onThirdPartyRegistrationFailed();
             }
+
+            @Override
+            public void onThirdPartyUnregistered() {
+            }
+
+            @Override
+            public void onThirdPartyUnregistrationFailed() {
+            }
+        });
+    }
+
+    /**
+     * Unregister the current sessions from the 3rd party server.
+     * @param listener the registration listener.
+     */
+    public void unregister(final ThirdPartyRegistrationListener listener) {
+        addSessionsRegistrationListener(listener);
+
+        if (mRegistrationState == RegistrationState.SERVER_UNREGISTRATING) {
+          // please wait
+        } else if (mRegistrationState != RegistrationState.SERVER_REGISTERED) {
+            Log.e(LOG_TAG, "unregisterSessions : invalid state " + mRegistrationState);
+            onThirdPartyUnregistrationFailed();
         } else {
-            mRegistrationState = RegistrationState.GCM_REGISTRATING;
-
-            new AsyncTask<Void, Void, String>() {
-                @Override
-                protected String doInBackground(Void... voids) {
-                    String pushKey = getPushKey(appContext);
-
-                    if (pushKey != null) {
-                        mPushKey = pushKey;
-                    }
-
-                    return mPushKey;
-                }
-
-                @Override
-                protected void onPostExecute(String pushKey) {
-                    mRegistrationState = (pushKey != null) ? RegistrationState.GCM_REGISTRED : RegistrationState.UNREGISTRATED;
-                    setStoredPushKey(pushKey);
-
-                    // warn the listener
-                    if (null != registrationListener) {
-                        try {
-                            if (pushKey != null) {
-                                registrationListener.onPusherRegistered();
-                            } else {
-                                registrationListener.onPusherRegistrationFailed();
-                            }
-                        } catch (Exception e) {
-                            Log.e(LOG_TAG, "registerPusher : onPusherRegistered/onPusherRegistrationFailed failed " + e.getLocalizedMessage());
-                        }
-                    }
-
-                    if (mRegistrationState == RegistrationState.GCM_REGISTRED) {
-                        // register the sessions to the 3rd party server
-                        // this setting should be updated from the listener
-                        if (useGCM()) {
-                            registerSessions(appContext, null);
-                        }
-                    }
-                }
-            }.execute();
+            mRegistrationState = RegistrationState.SERVER_UNREGISTRATING;
+            unregister(new ArrayList<>(Matrix.getInstance(mContext).getSessions()), 0);
         }
     }
+
+    /**
+     * Recursive method to unregister a MXSessions list.
+     * @param sessions the sessions list.
+     * @param index the index of the MX sessions to register.
+     */
+    private void unregister(final ArrayList<MXSession> sessions, final int index) {
+        // reach this end of the list ?
+        if (index >= sessions.size()) {
+            mRegistrationState = RegistrationState.GCM_REGISTRED;
+
+            // trigger a registration if the user disabled thme while the unregistration was processing
+            if (useGCM() && areDeviceNotificationsAllowed() && Matrix.hasValidSessions() ) {
+                register(null);
+            }
+
+            onThirdPartyUnregistered();
+            return;
+        }
+
+        MXSession session = sessions.get(index);
+
+        unregister(session , new ThirdPartyRegistrationListener() {
+            @Override
+            public void onThirdPartyRegistered() {
+            }
+
+            @Override
+            public void onThirdPartyRegistrationFailed() {
+            }
+
+            @Override
+            public void onThirdPartyUnregistered() {
+                unregister(sessions, index+1);
+            }
+
+            @Override
+            public void onThirdPartyUnregistrationFailed() {
+                mRegistrationState = RegistrationState.SERVER_REGISTERED;
+                onThirdPartyUnregistrationFailed();
+            }
+        });
+    }
+
+    /**
+     * Unregister a session from the 3rd-party app server
+     * @param session the session.
+     * @param listener the lisneter
+     */
+    public void unregister(final MXSession session, final ThirdPartyRegistrationListener listener) {
+        session.getPushersRestClient()
+                .removeHttpPusher(mRegistrationToken, DEFAULT_PUSHER_APP_ID, computePushTag(session),
+                        mPusherLang, mPusherAppName, mBasePusherDeviceName,
+                        DEFAULT_PUSHER_URL, new ApiCallback<Void>() {
+                            @Override
+                            public void onSuccess(Void info) {
+                                Log.d(LOG_TAG, "unregisterSession succeeded");
+
+                                if (null != listener) {
+                                    try {
+                                        listener.onThirdPartyUnregistered();
+                                    } catch (Exception e) {
+                                    }
+                                }
+                            }
+
+                            private void onError(final String message) {
+                                if (session.isAlive()) {
+                                    Log.e(LOG_TAG, "fail to unregister " + session.getMyUserId() + " (" + message + ")");
+
+                                    if (null != listener) {
+                                        try {
+                                            listener.onThirdPartyUnregistrationFailed();
+                                        } catch (Exception e) {
+                                        }
+                                    }
+                                }
+                            }
+
+                            @Override
+                            public void onNetworkError(Exception e) {
+                                Log.e(LOG_TAG, "unregisterSession onNetworkError " + e.getMessage());
+                                onError(e.getLocalizedMessage());
+                            }
+
+                            @Override
+                            public void onMatrixError(MatrixError e) {
+                                Log.e(LOG_TAG, "unregisterSession onMatrixError " + e.errcode);
+                                onError(e.getLocalizedMessage());
+                            }
+
+                            @Override
+                            public void onUnexpectedError(Exception e) {
+                                Log.e(LOG_TAG, "unregisterSession onUnexpectedError " + e.getMessage());
+                                onError(e.getLocalizedMessage());
+                            }
+                        });
+    }
+
+    //================================================================================
+    // statuses
+    //================================================================================
+
+    /**
+     * Tells if GCM has a push key.
+     */
+    public boolean hasRegistrationToken() {
+        return null != mRegistrationToken;
+    }
+
+    /**
+     * Tell if the events polling thread should be used.
+     * It should be used only if GCM is disabled or failed.
+     * @return true if the polling thread approach must be used, false otherwise
+     */
+    public boolean usePollingThread() {
+        return !isGCMRegistred() && !isGCMRegistrating();
+    }
+
+    /**
+     * Tell if GCM is rregistred i.e. ready to use
+     */
+    public boolean isGCMRegistred() {
+        return (mRegistrationState == RegistrationState.GCM_REGISTRED) || (mRegistrationState == RegistrationState.SERVER_REGISTRATING) || (mRegistrationState == RegistrationState.SERVER_REGISTERED);
+    }
+
+    /**
+     * Tells if the GCM is registrating
+     */
+    private boolean isGCMRegistrating() {
+        return (mRegistrationState == RegistrationState.SERVER_REGISTRATING) || (mRegistrationState == RegistrationState.SERVER_UNREGISTRATING);
+    }
+
+    /**
+     * Tells if the GCM is registrered on server
+     */
+    public boolean isServerRegistred() {
+        return mRegistrationState == RegistrationState.SERVER_REGISTERED;
+    }
+
+    /**
+     * Tells if the GCM is unregistrered on server
+     */
+    public boolean isServerUnRegistred() {
+        return mRegistrationState == RegistrationState.GCM_REGISTRED;
+    }
+
+    //================================================================================
+    // GCM preferences
+    //================================================================================
 
     /**
      * Tells if the client prefers GCM over events polling thread.
@@ -333,26 +786,53 @@ public final class GcmRegistrationManager {
     }
 
     /**
-     * Tells if GCM has a push key.
+     * @return true the notifications must be triggered on this device
      */
-    public boolean hasPushKey() {
-        return null != mPushKey;
-    }
-
-    /**
-     * @return true if the push registration is allowed on this device
-     */
-    public boolean isNotificationsAllowed() {
+    public boolean areDeviceNotificationsAllowed() {
         return getSharedPreferences().getBoolean(PREFS_ALLOW_NOTIFICATIONS, true);
     }
 
     /**
-     * Update the push registration management
-     * @param isAllowed true to allow the server registration
+     * Update the device notifications management.
+     * @param areAllowed true to enable the device notifications.
      */
-    public void setIsNotificationsAllowed(boolean isAllowed) {
+    public void setAreDeviceNotificationsAllowed(boolean areAllowed) {
         getSharedPreferences().edit()
-                .putBoolean(PREFS_ALLOW_NOTIFICATIONS, isAllowed)
+                .putBoolean(PREFS_ALLOW_NOTIFICATIONS, areAllowed)
+                .apply();
+    }
+
+    /**
+     * @return true if the notifications should turn the screen on for 3 seconds.
+     */
+    public boolean doNotificationsTurnScreenOn() {
+        return getSharedPreferences().getBoolean(PREFS_TURN_SCREEN_ON, true);
+    }
+
+    /**
+     * Update the screen on management when a notification is received.
+     * @param flag true to enable the device notifications.
+     */
+    public void setNotificationsTurnScreenOn(boolean flag) {
+        getSharedPreferences().edit()
+                .putBoolean(PREFS_TURN_SCREEN_ON, flag)
+                .apply();
+    }
+
+    /**
+     * @return true if a new notification does not have sound and the current displayed one has.
+     */
+    public boolean preferNotificationWithSound() {
+        return getSharedPreferences().getBoolean(PREFS_KEEP_NOTIFS_WITH_SOUND, false);
+    }
+
+    /**
+     * Update the notificatioon with sound preference
+     * @param flag true to prefer notification with sound.
+     */
+    public void setPreferNotificationWithSound(boolean flag) {
+        getSharedPreferences().edit()
+                .putBoolean(PREFS_KEEP_NOTIFS_WITH_SOUND, flag)
                 .apply();
     }
 
@@ -422,513 +902,116 @@ public final class GcmRegistrationManager {
                 .apply();
     }
 
-    /**
-     * Tell if the events polling thread should be used.
-     * It should be used only if GCM is disabled or failed.
-     * @return true if the polling thread approach must be used, false otherwise
-     */
-    public boolean usePollingThread() {
-        return !isGCMRegistred() && !isGCMRegistrating();
-    }
+    //================================================================================
+    // GCM push key
+    //================================================================================
 
     /**
-     * Tell if GCM is rregistred i.e. ready to use
+     * @return the GCM preferences
      */
-    public boolean isGCMRegistred() {
-        return (mRegistrationState == RegistrationState.GCM_REGISTRED) || (mRegistrationState == RegistrationState.SERVER_REGISTRATING) || (mRegistrationState == RegistrationState.SERVER_REGISTERED);
-    }
-
-    /**
-     * Tells if the GCM is registrating
-     */
-    public boolean isGCMRegistrating() {
-        return (mRegistrationState == RegistrationState.SERVER_REGISTRATING) || (mRegistrationState == RegistrationState.SERVER_UNREGISTRATING);
-    }
-
-    /**
-     * Tells if the GCM is registrered on server
-     */
-    public boolean isServerRegistred() {
-        return mRegistrationState == RegistrationState.SERVER_REGISTERED;
-    }
-
-    /**
-     * Tells if the GCM is unregistrered on server
-     */
-    public boolean isServerUnRegistred() {
-        return mRegistrationState == RegistrationState.GCM_REGISTRED;
-    }
-
-    /**
-     * Retrieve the GCM push key.
-     * @param appContext the application context
-     * @return the GCM pushKey
-     */
-    private String getPushKey(Context appContext) {
-        String pushKey = getStoredPushKey();
-
-        if (pushKey == null) {
-            pushKey = GCMHelper.getPushKey(appContext);
-        }
-        return pushKey;
-    }
-
-    /**
-     * Compute the profileTag for a session
-     * @param session the session
-     * @return the profile tag
-     */
-    private String computePushTag(final MXSession session) {
-        String tag =  mPusherBaseFileTag + "_" + Math.abs(session.getMyUserId().hashCode());
-
-        // tag max length : 32 bytes
-        if (tag.length() > 32) {
-            tag = Math.abs(tag.hashCode()) + "";
-        }
-
-        return tag;
-    }
-
-    /**
-     * Register the session to the 3rd-party app server
-     * @param session the session to register.
-     * @param listener the registration listener
-     */
-    public void registerSession(final MXSession session, boolean append, final GcmSessionRegistration listener) {
-        // test if the push server registration is allowed
-        if (! isNotificationsAllowed() || !useGCM()) {
-            if (!isNotificationsAllowed()) {
-                Log.d(LOG_TAG, "registerPusher : the user disabled it.");
-            }  else {
-                Log.d(LOG_TAG, "registerPusher : GCM is disabled.");
-            }
-
-            if (null != listener) {
-                try {
-                    listener.onSessionRegistrationFailed();
-                }  catch (Exception e) {
-                }
-            }
-
-            return;
-        }
-
-        session.getPushersRestClient()
-                .addHttpPusher(mPushKey, mPusherAppId, computePushTag(session),
-                        mPusherLang, mPusherAppName, mBasePusherDeviceName,
-                        mPusherUrl, append, new ApiCallback<Void>() {
-                            @Override
-                            public void onSuccess(Void info) {
-                                Log.d(LOG_TAG, "registerPusher succeeded");
-
-                                if (null != listener) {
-                                    try {
-                                        listener.onSessionRegistred();
-                                    } catch (Exception e) {
-                                    }
-                                }
-                            }
-
-                            private void onError(final String message) {
-                                Log.e(LOG_TAG, "fail to register " + session.getMyUserId() + " (" + message + ")");
-
-                                if (null != listener) {
-                                    try {
-                                        listener.onSessionRegistrationFailed();
-                                    } catch (Exception e) {
-                                    }
-                                }
-                            }
-
-                            @Override
-                            public void onNetworkError(Exception e) {
-                                Log.e(LOG_TAG, "registerPusher onNetworkError " + e.getMessage());
-                                onError(e.getLocalizedMessage());
-                            }
-
-                            @Override
-                            public void onMatrixError(MatrixError e) {
-                                Log.e(LOG_TAG, "registerPusher onMatrixError " + e.errcode);
-                                onError(e.getLocalizedMessage());
-                            }
-
-                            @Override
-                            public void onUnexpectedError(Exception e) {
-                                Log.e(LOG_TAG, "registerPusher onUnexpectedError " + e.getMessage());
-                                onError(e.getLocalizedMessage());
-                            }
-                        });
-    }
-
-
-    public void addSessionsRegistrationListener(final GcmSessionRegistration listener) {
-        synchronized (this) {
-            if ((null != listener) && (mSessionsregistrationListener.indexOf(listener) == -1)) {
-                mSessionsregistrationListener.add(listener);
-            }
-        }
-    }
-
-    private void onSessionsRegistred() {
-        synchronized (this) {
-            for(GcmSessionRegistration listener : mSessionsregistrationListener) {
-                try {
-                    listener.onSessionRegistred();
-                } catch (Exception e) {
-
-                }
-            }
-
-            mSessionsregistrationListener.clear();
-        }
-    }
-
-    private void onSessionsRegistrationFailed() {
-        synchronized (this) {
-            for(GcmSessionRegistration listener : mSessionsregistrationListener) {
-                try {
-                    listener.onSessionRegistrationFailed();
-                } catch (Exception e) {
-
-                }
-            }
-
-            mSessionsregistrationListener.clear();
-        }
-    }
-
-    private void onSessionsUnregistred() {
-        synchronized (this) {
-            for(GcmSessionRegistration listener : mSessionsregistrationListener) {
-                try {
-                    listener.onSessionUnregistred();
-                } catch (Exception e) {
-
-                }
-            }
-
-            mSessionsregistrationListener.clear();
-        }
-    }
-
-    private void onSessionsUnregistrationFailed() {
-        synchronized (this) {
-            for(GcmSessionRegistration listener : mSessionsregistrationListener) {
-                try {
-                    listener.onSessionUnregistrationFailed();
-                } catch (Exception e) {
-
-                }
-            }
-
-            mSessionsregistrationListener.clear();
-        }
-    }
-
-    public void reregisterSessions(final Context appContext, final GcmSessionRegistration listener) {
-        if ((mRegistrationState == RegistrationState.SERVER_REGISTERED) || (mRegistrationState == RegistrationState.GCM_REGISTRED)){
-            mRegistrationState = RegistrationState.GCM_REGISTRED;
-
-            registerSessions(appContext, listener);
-        } else {
-            if (null != listener) {
-                try {
-                    listener.onSessionRegistrationFailed();
-                } catch (Exception e) {
-                }
-            }
-        }
-    }
-
-    /**
-     * Register the current sessions to the 3rd party GCM server
-     * @param listener the registration listener.
-     */
-    public void registerSessions(final Context appContext, final GcmSessionRegistration listener) {
-        if (mRegistrationState == RegistrationState.SERVER_REGISTRATING) {
-            addSessionsRegistrationListener(listener);
-        } else if (mRegistrationState == RegistrationState.UNREGISTRATED) {
-            Log.d(LOG_TAG, "registerSessions unregistrated : try to register again");
-
-            // if the registration failed
-            // try to register again
-            registerPusher(appContext, new GcmRegistrationIdListener() {
-                @Override
-                public void onPusherRegistered() {
-                    Log.d(LOG_TAG, "GCM registration failed again : register on server side");
-                    registerSessions(appContext, listener);
-                }
-
-                @Override
-                public void onPusherRegistrationFailed() {
-                    Log.d(LOG_TAG, "registerSessions unregistrated : GCM registration failed again");
-
-                    if (null != listener) {
-                        try {
-                            listener.onSessionRegistrationFailed();
-                        } catch (Exception e) {
-                        }
-                    }
-                }
-            });
-        } else if (mRegistrationState == RegistrationState.SERVER_REGISTERED) {
-            Log.e(LOG_TAG, "registerSessions : already registred");
-
-            if (null != listener) {
-                try {
-                    listener.onSessionRegistred();
-                } catch (Exception e) {
-                }
-            }
-        } else if (mRegistrationState != RegistrationState.GCM_REGISTRED) {
-            Log.e(LOG_TAG, "registerSessions : invalid state " + mRegistrationState);
-
-            if (null != listener) {
-                try {
-                    listener.onSessionRegistrationFailed();
-                } catch (Exception e) {
-                }
-            }
-        } else {
-            mRegistrationState = RegistrationState.SERVER_REGISTRATING;
-            addSessionsRegistrationListener(listener);
-            registerSessions(new ArrayList<MXSession>(Matrix.getInstance(mContext).getSessions()), 0);
-        }
-    }
-
-    /**
-     * Recursive method to register a MXSessions list.
-     * @param sessions the sessions list.
-     * @param index the index of the MX sessions to register.
-     */
-    private void registerSessions(final ArrayList<MXSession> sessions, final int index) {
-        // reach this end of the list ?
-        if (index >= sessions.size()) {
-            Log.d(LOG_TAG, "registerSessions : all the sessions are registred");
-            mRegistrationState = RegistrationState.SERVER_REGISTERED;
-            onSessionsRegistred();
-
-            // get the pushers list
-            refreshPushersList(sessions, null);
-            return;
-        }
-
-        final MXSession session = sessions.get(index);
-
-        registerSession(session, (index > 0), new GcmSessionRegistration() {
-            @Override
-            public void onSessionRegistred() {
-                Log.d(LOG_TAG, "registerSessions : session " + session.getMyUserId() + " is registred");
-                registerSessions(sessions, index + 1);
-            }
-
-            @Override
-            public void onSessionRegistrationFailed() {
-                Log.d(LOG_TAG, "registerSessions : onSessionRegistrationFailed " + session.getMyUserId());
-
-                mRegistrationState = RegistrationState.GCM_REGISTRED;
-                onSessionsRegistrationFailed();
-            }
-
-            @Override
-            public void onSessionUnregistred() {
-            }
-
-            @Override
-            public void onSessionUnregistrationFailed() {
-            }
-        });
-    }
-
-    /**
-     * Unregister the user identified from his matrix Id from the 3rd-party app server
-     * @param session
-     */
-    public void unregisterSession(final MXSession session, final GcmSessionRegistration listener) {
-        session.getPushersRestClient()
-                .removeHttpPusher(mPushKey, mPusherAppId, computePushTag(session),
-                        mPusherLang, mPusherAppName, mBasePusherDeviceName,
-                        mPusherUrl, new ApiCallback<Void>() {
-                            @Override
-                            public void onSuccess(Void info) {
-                                Log.d(LOG_TAG, "unregisterSession succeeded");
-
-                                if (null != listener) {
-                                    try {
-                                        listener.onSessionUnregistred();
-                                    } catch (Exception e) {
-                                    }
-                                }
-                            }
-
-                            private void onError(final String message) {
-                                if (session.isAlive()) {
-                                    Log.e(LOG_TAG, "fail to unregister " + session.getMyUserId() + " (" + message + ")");
-
-                                    if (null != listener) {
-                                        try {
-                                            listener.onSessionUnregistrationFailed();
-                                        } catch (Exception e) {
-                                        }
-                                    }
-                                }
-                            }
-
-                            @Override
-                            public void onNetworkError(Exception e) {
-                                Log.e(LOG_TAG, "unregisterSession onNetworkError " + e.getMessage());
-                                onError(e.getLocalizedMessage());
-                            }
-
-                            @Override
-                            public void onMatrixError(MatrixError e) {
-                                Log.e(LOG_TAG, "unregisterSession onMatrixError " + e.errcode);
-                                onError(e.getLocalizedMessage());
-                            }
-
-                            @Override
-                            public void onUnexpectedError(Exception e) {
-                                Log.e(LOG_TAG, "unregisterSession onUnexpectedError " + e.getMessage());
-                                onError(e.getLocalizedMessage());
-                            }
-                        });
-    }
-
-    /**
-     * Unregister the current sessions from the 3rd party GCM server
-     * @param listener the registration listener.
-     */
-    public void unregisterSessions(final GcmSessionRegistration listener) {
-        if (mRegistrationState == RegistrationState.SERVER_UNREGISTRATING) {
-            addSessionsRegistrationListener(listener);
-        } else if (mRegistrationState != RegistrationState.SERVER_REGISTERED) {
-            Log.e(LOG_TAG, "unregisterSessions : invalid state " + mRegistrationState);
-
-            if (null != listener) {
-                try {
-                    listener.onSessionUnregistrationFailed();
-                } catch (Exception e) {
-                }
-            }
-        } else {
-            mRegistrationState = RegistrationState.SERVER_UNREGISTRATING;
-            addSessionsRegistrationListener(listener);
-            unregisterSessions(new ArrayList<MXSession>(Matrix.getInstance(mContext).getSessions()), 0);
-        }
-    }
-
-    /**
-     * Recursive method to unregister a MXSessions list.
-     * @param sessions the sessions list.
-     * @param index the index of the MX sessions to register.
-     */
-    private void unregisterSessions(final ArrayList<MXSession> sessions, final int index) {
-        // reach this end of the list ?
-        if (index >= sessions.size()) {
-            mRegistrationState = RegistrationState.GCM_REGISTRED;
-            onSessionsUnregistred();
-            return;
-        }
-
-        MXSession session = sessions.get(index);
-
-        unregisterSession(session , new GcmSessionRegistration() {
-            @Override
-            public void onSessionRegistred() {
-            }
-
-            @Override
-            public void onSessionRegistrationFailed() {
-            }
-
-            @Override
-            public void onSessionUnregistred() {
-                unregisterSessions(sessions, index+1);
-            }
-
-            @Override
-            public void onSessionUnregistrationFailed() {
-                mRegistrationState = RegistrationState.SERVER_REGISTERED;
-                onSessionsUnregistrationFailed();
-            }
-        });
+    private SharedPreferences getSharedPreferences() {
+        return mContext.getSharedPreferences(PREFS_GCM, Context.MODE_PRIVATE);
     }
 
     /**
      * @return the GCM registration stored for this version of the app or null if none is stored.
      */
-    private String getStoredPushKey() {
-        return getSharedPreferences().getString(getPushKeyKey(), null);
+    private String getStoredRegistrationToken() {
+        return getSharedPreferences().getString(mRegistrationTokenPreferenceKey, null);
     }
 
     /**
      * Set the GCM registration for the currently-running version of this app.
-     * @param pushKey
+     * @param registrationToken the registration token
      */
-    private void setStoredPushKey(String pushKey) {
-        String key = getPushKeyKey();
-        if (key == null) {
-            Log.e(LOG_TAG, "Failed to store registration ID");
-            return;
-        }
-
-        Log.d(LOG_TAG, "Saving push key " + pushKey + " under key " + key);
+    private void setStoredRegistrationToken(String registrationToken) {
+        Log.d(LOG_TAG, "Saving registration token " + registrationToken + " under key " + mRegistrationTokenPreferenceKey);
         getSharedPreferences().edit()
-                .putString(key, pushKey)
+                .putString(mRegistrationTokenPreferenceKey, registrationToken)
                 .apply();
     }
 
-    private SharedPreferences getSharedPreferences() {
-        return mContext.getSharedPreferences(PREFS_GCM, Context.MODE_PRIVATE);
-    }
+    //================================================================================
+    // Events dispatcher
+    //================================================================================
 
-    private String getPushKeyKey() {
-        try {
-            PackageInfo packageInfo = mContext.getPackageManager()
-                    .getPackageInfo(mContext.getPackageName(), 0);
-            return PREFS_KEY_REG_ID_PREFIX + Integer.toString(packageInfo.versionCode);
-        } catch (PackageManager.NameNotFoundException e) {
-            Log.e(LOG_TAG, "getPushKeyKey failed " + e.getLocalizedMessage());
-            throw new RuntimeException(e);
+    /**
+     * Add a listener to the third party server.
+     * @param listener the new listener.
+     */
+    private void addSessionsRegistrationListener(final ThirdPartyRegistrationListener listener) {
+        synchronized (this) {
+            if ((null != listener) && (mThirdPartyRegistrationListeners.indexOf(listener) == -1)) {
+                mThirdPartyRegistrationListeners.add(listener);
+            }
         }
     }
 
     /**
-     * Save the GCM info to the preferences
+     * Dispatch the onThirdPartyRegistered to the listeners.
      */
-    private void SaveGCMData() {
-        try {
-            SharedPreferences preferences = getSharedPreferences();
-            SharedPreferences.Editor editor = preferences.edit();
+    private void onThirdPartyRegistered() {
+        synchronized (this) {
+            for(ThirdPartyRegistrationListener listener : mThirdPartyRegistrationListeners) {
+                try {
+                    listener.onThirdPartyRegistered();
+                } catch (Exception e) {
+                    Log.e(LOG_TAG, "onSessionsRegistered " + e.getLocalizedMessage());
+                }
+            }
 
-            editor.putString(PREFS_PUSHER_APP_ID_KEY, mPusherAppId);
-            editor.putString(PREFS_PUSHER_URL_KEY, mPusherUrl);
-            editor.putString(PREFS_PUSHER_FILE_TAG_KEY, mPusherBaseFileTag);
-
-            editor.commit();
-        } catch (Exception e) {
-            Log.e(LOG_TAG, "SaveGCMData failed " + e.getLocalizedMessage());
+            mThirdPartyRegistrationListeners.clear();
         }
     }
 
     /**
-     * Load the GCM info from the preferences
+     * Dispatch the onThirdPartyRegistrationFailed to the listeners.
      */
-    private void loadGcmData() {
-        try {
-            SharedPreferences preferences = getSharedPreferences();
+    private void onThirdPartyRegistrationFailed() {
+        synchronized (this) {
+            for(ThirdPartyRegistrationListener listener : mThirdPartyRegistrationListeners) {
+                try {
+                    listener.onThirdPartyRegistrationFailed();
+                } catch (Exception e) {
+                    Log.e(LOG_TAG, "onSessionsRegistrationFailed " + e.getLocalizedMessage());
+                }
+            }
 
-            String pusherAppId = preferences.getString(PREFS_PUSHER_APP_ID_KEY, null);
-            mPusherAppId = TextUtils.isEmpty(pusherAppId) ? DEFAULT_PUSHER_APP_ID : pusherAppId;
+            mThirdPartyRegistrationListeners.clear();
+        }
+    }
 
-            String pusherUrl = preferences.getString(PREFS_PUSHER_URL_KEY, null);
-            mPusherUrl = TextUtils.isEmpty(pusherUrl) ? DEFAULT_PUSHER_URL : pusherUrl;
+    /**
+     * Dispatch the onThirdPartyUnregistered to the listeners.
+     */
+    private void onThirdPartyUnregistered() {
+        synchronized (this) {
+            for(ThirdPartyRegistrationListener listener : mThirdPartyRegistrationListeners) {
+                try {
+                    listener.onThirdPartyUnregistered();
+                } catch (Exception e) {
+                    Log.e(LOG_TAG, "onSessionUnregistered " + e.getLocalizedMessage());
+                }
+            }
 
-            String pusherFileTag = preferences.getString(PREFS_PUSHER_FILE_TAG_KEY, null);
-            mPusherBaseFileTag = TextUtils.isEmpty(pusherFileTag) ? DEFAULT_PUSHER_FILE_TAG : pusherFileTag;
+            mThirdPartyRegistrationListeners.clear();
+        }
+    }
 
-        } catch (Exception e) {
-            Log.e(LOG_TAG, "loadGcmData failed " + e.getLocalizedMessage());
+    /**
+     * Dispatch the onThirdPartyUnregistrationFailed to the listeners.
+     */
+    private void onThirdPartyUnregistrationFailed() {
+        synchronized (this) {
+            for(ThirdPartyRegistrationListener listener : mThirdPartyRegistrationListeners) {
+                try {
+                    listener.onThirdPartyUnregistrationFailed();
+                } catch (Exception e) {
+
+                }
+            }
+
+            mThirdPartyRegistrationListeners.clear();
         }
     }
 }

--- a/vector/src/main/java/im/vector/services/EventStreamService.java
+++ b/vector/src/main/java/im/vector/services/EventStreamService.java
@@ -609,7 +609,7 @@ public class EventStreamService extends Service {
 
         GcmRegistrationManager gcmGcmRegistrationManager = Matrix.getInstance(getApplicationContext()).getSharedGcmRegistrationManager();
 
-        if (!gcmGcmRegistrationManager.isNotificationsAllowed()) {
+        if (!gcmGcmRegistrationManager.areDeviceNotificationsAllowed()) {
             Log.d(LOG_TAG, "onBingEvent : the push has been disable on this device");
             return;
         }

--- a/vector/src/main/java/im/vector/services/EventStreamService.java
+++ b/vector/src/main/java/im/vector/services/EventStreamService.java
@@ -793,7 +793,7 @@ public class EventStreamService extends Service {
                     nm.notify(MSG_NOTIFICATION_ID, mLatestNotification);
 
                     // turn the screen on
-                    if (mGcmRegistrationManager.turnScreenOn()) {
+                    if (mGcmRegistrationManager.isScreenTurnedOn()) {
                         // turn the screen on for 3 seconds
                         PowerManager pm = (PowerManager) getSystemService(Context.POWER_SERVICE);
                         PowerManager.WakeLock wl = pm.newWakeLock(PowerManager.SCREEN_BRIGHT_WAKE_LOCK | PowerManager.ACQUIRE_CAUSES_WAKEUP, "MXEventListener");

--- a/vector/src/main/java/im/vector/services/EventStreamService.java
+++ b/vector/src/main/java/im/vector/services/EventStreamService.java
@@ -52,7 +52,7 @@ import im.vector.ViewedRoomTracker;
 import im.vector.activity.CallViewActivity;
 import im.vector.activity.CommonActivityUtils;
 import im.vector.activity.VectorHomeActivity;
-import im.vector.gcm.GCMRegistrationManager;
+import im.vector.gcm.GcmRegistrationManager;
 import im.vector.util.NotificationUtils;
 import im.vector.util.VectorUtils;
 
@@ -118,7 +118,7 @@ public class EventStreamService extends Service {
     private static EventStreamService mActiveEventStreamService = null;
 
     // the GCM manager
-    private GCMRegistrationManager mGcmRegistrationManager;
+    private GcmRegistrationManager mGcmRegistrationManager;
 
     /**
      * @return the event stream instance
@@ -524,7 +524,7 @@ public class EventStreamService extends Service {
         // detect if the polling thread must be started
         // i.e a session must be defined
         // and GCM disabled or GCM registration failed
-        if ((!mGcmRegistrationManager.useGCM() || mGcmRegistrationManager.usePollingThread()) && mGcmRegistrationManager.isBackgroundSyncAllowed()) {
+        if ((!mGcmRegistrationManager.useGCM() || !mGcmRegistrationManager.isServerRegistred()) && mGcmRegistrationManager.isBackgroundSyncAllowed()) {
             Notification notification = buildNotification();
             startForeground(NOTIFICATION_ID, notification);
             mIsForeground = true;
@@ -793,7 +793,7 @@ public class EventStreamService extends Service {
                     nm.notify(MSG_NOTIFICATION_ID, mLatestNotification);
 
                     // turn the screen on
-                    if (mGcmRegistrationManager.doNotificationsTurnScreenOn()) {
+                    if (mGcmRegistrationManager.turnScreenOn()) {
                         // turn the screen on for 3 seconds
                         PowerManager pm = (PowerManager) getSystemService(Context.POWER_SERVICE);
                         PowerManager.WakeLock wl = pm.newWakeLock(PowerManager.SCREEN_BRIGHT_WAKE_LOCK | PowerManager.ACQUIRE_CAUSES_WAKEUP, "MXEventListener");

--- a/vector/src/main/java/im/vector/services/EventStreamService.java
+++ b/vector/src/main/java/im/vector/services/EventStreamService.java
@@ -117,6 +117,9 @@ public class EventStreamService extends Service {
     // static instance
     private static EventStreamService mActiveEventStreamService = null;
 
+    // the GCM manager
+    private GCMRegistrationManager mGcmRegistrationManager;
+
     /**
      * @return the event stream instance
      */
@@ -395,7 +398,9 @@ public class EventStreamService extends Service {
             }
         }
 
-        if (!Matrix.getInstance(getApplicationContext()).getSharedGCMRegistrationManager().useGCM()) {
+        mGcmRegistrationManager = Matrix.getInstance(getApplicationContext()).getSharedGCMRegistrationManager();
+
+        if (!mGcmRegistrationManager.useGCM()) {
             updateServiceForegroundState();
         }
 
@@ -516,12 +521,10 @@ public class EventStreamService extends Service {
             return;
         }
 
-        GCMRegistrationManager gcmnMgr = Matrix.getInstance(this).getSharedGCMRegistrationManager();
-
         // detect if the polling thread must be started
         // i.e a session must be defined
         // and GCM disabled or GCM registration failed
-        if ((!gcmnMgr.useGCM() || gcmnMgr.usePollingThread()) && gcmnMgr.isBackgroundSyncAllowed()) {
+        if ((!mGcmRegistrationManager.useGCM() || mGcmRegistrationManager.usePollingThread()) && mGcmRegistrationManager.isBackgroundSyncAllowed()) {
             Notification notification = buildNotification();
             startForeground(NOTIFICATION_ID, notification);
             mIsForeground = true;
@@ -607,9 +610,7 @@ public class EventStreamService extends Service {
             bingRule = mDefaultBingRule;
         }
 
-        GCMRegistrationManager gcmRegistrationManager = Matrix.getInstance(getApplicationContext()).getSharedGCMRegistrationManager();
-
-        if (!gcmRegistrationManager.areDeviceNotificationsAllowed()) {
+        if (!mGcmRegistrationManager.areDeviceNotificationsAllowed()) {
             Log.d(LOG_TAG, "onBingEvent : the push has been disable on this device");
             return;
         }
@@ -791,11 +792,16 @@ public class EventStreamService extends Service {
                     nm.cancelAll();
                     nm.notify(MSG_NOTIFICATION_ID, mLatestNotification);
 
-                    // turn the screen on for 3 seconds
-                    PowerManager pm = (PowerManager) getSystemService(Context.POWER_SERVICE);
-                    PowerManager.WakeLock wl = pm.newWakeLock(PowerManager.SCREEN_BRIGHT_WAKE_LOCK | PowerManager.ACQUIRE_CAUSES_WAKEUP, "MXEventListener");
-                    wl.acquire(3000);
-                    wl.release();
+                    // turn the screen on
+                    if (mGcmRegistrationManager.doNotificationsTurnScreenOn()) {
+                        // turn the screen on for 3 seconds
+                        PowerManager pm = (PowerManager) getSystemService(Context.POWER_SERVICE);
+                        PowerManager.WakeLock wl = pm.newWakeLock(PowerManager.SCREEN_BRIGHT_WAKE_LOCK | PowerManager.ACQUIRE_CAUSES_WAKEUP, "MXEventListener");
+                        wl.acquire(3000);
+                        wl.release();
+                    }
+
+
                 } catch (Exception e) {
                     Log.e(LOG_TAG, "onLiveEventsChunkProcessed crashed " + e.getLocalizedMessage());
                 }

--- a/vector/src/main/java/im/vector/services/EventStreamService.java
+++ b/vector/src/main/java/im/vector/services/EventStreamService.java
@@ -52,7 +52,7 @@ import im.vector.ViewedRoomTracker;
 import im.vector.activity.CallViewActivity;
 import im.vector.activity.CommonActivityUtils;
 import im.vector.activity.VectorHomeActivity;
-import im.vector.gcm.GcmRegistrationManager;
+import im.vector.gcm.GCMRegistrationManager;
 import im.vector.util.NotificationUtils;
 import im.vector.util.VectorUtils;
 
@@ -395,7 +395,7 @@ public class EventStreamService extends Service {
             }
         }
 
-        if (!Matrix.getInstance(getApplicationContext()).getSharedGcmRegistrationManager().useGCM()) {
+        if (!Matrix.getInstance(getApplicationContext()).getSharedGCMRegistrationManager().useGCM()) {
             updateServiceForegroundState();
         }
 
@@ -516,7 +516,7 @@ public class EventStreamService extends Service {
             return;
         }
 
-        GcmRegistrationManager gcmnMgr = Matrix.getInstance(this).getSharedGcmRegistrationManager();
+        GCMRegistrationManager gcmnMgr = Matrix.getInstance(this).getSharedGCMRegistrationManager();
 
         // detect if the polling thread must be started
         // i.e a session must be defined
@@ -607,9 +607,9 @@ public class EventStreamService extends Service {
             bingRule = mDefaultBingRule;
         }
 
-        GcmRegistrationManager gcmGcmRegistrationManager = Matrix.getInstance(getApplicationContext()).getSharedGcmRegistrationManager();
+        GCMRegistrationManager gcmRegistrationManager = Matrix.getInstance(getApplicationContext()).getSharedGCMRegistrationManager();
 
-        if (!gcmGcmRegistrationManager.areDeviceNotificationsAllowed()) {
+        if (!gcmRegistrationManager.areDeviceNotificationsAllowed()) {
             Log.d(LOG_TAG, "onBingEvent : the push has been disable on this device");
             return;
         }

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -588,6 +588,9 @@
 
     <string name="settings_enable_all_notif">Enable notifications for this account</string>
     <string name="settings_enable_this_device">Enable notifications for this device</string>
+    <string name="settings_turn_screen_on">Turn the screen on for 3 seconds</string>
+    <string name="settings_prioritise_audio_notifs">Prioritise audible notifications over silent ones</string>
+
     <string name="settings_containing_my_name">Msgs containing my name</string>
     <string name="settings_messages_in_one_to_one">Msgs in one-to-one chats</string>
     <string name="settings_messages_in_group_chat">Msgs in group chats</string>

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -589,7 +589,6 @@
     <string name="settings_enable_all_notif">Enable notifications for this account</string>
     <string name="settings_enable_this_device">Enable notifications for this device</string>
     <string name="settings_turn_screen_on">Turn the screen on for 3 seconds</string>
-    <string name="settings_prioritise_audio_notifs">Prioritise audible notifications over silent ones</string>
 
     <string name="settings_containing_my_name">Msgs containing my name</string>
     <string name="settings_messages_in_one_to_one">Msgs in one-to-one chats</string>

--- a/vector/src/main/res/xml/vector_settings_preferences.xml
+++ b/vector/src/main/res/xml/vector_settings_preferences.xml
@@ -33,15 +33,13 @@
 
         <SwitchPreference
             android:title="@string/settings_enable_this_device"
-            android:key="@string/settings_enable_this_device"/>
+            android:key="@string/settings_enable_this_device"
+            android:dependency="@string/settings_enable_all_notif"/>
 
         <SwitchPreference
             android:title="@string/settings_turn_screen_on"
-            android:key="@string/settings_turn_screen_on"/>
-
-        <SwitchPreference
-            android:title="@string/settings_prioritise_audio_notifs"
-            android:key="@string/settings_prioritise_audio_notifs"/>
+            android:key="@string/settings_turn_screen_on"
+            android:dependency="@string/settings_enable_all_notif"/>
 
         <SwitchPreference
             android:title="@string/settings_containing_my_name"

--- a/vector/src/main/res/xml/vector_settings_preferences.xml
+++ b/vector/src/main/res/xml/vector_settings_preferences.xml
@@ -36,6 +36,14 @@
             android:key="@string/settings_enable_this_device"/>
 
         <SwitchPreference
+            android:title="@string/settings_turn_screen_on"
+            android:key="@string/settings_turn_screen_on"/>
+
+        <SwitchPreference
+            android:title="@string/settings_prioritise_audio_notifs"
+            android:key="@string/settings_prioritise_audio_notifs"/>
+
+        <SwitchPreference
             android:title="@string/settings_containing_my_name"
             android:key="@string/settings_containing_my_name"
             android:dependency="@string/settings_enable_all_notif"/>


### PR DESCRIPTION
-> refactor GCMRegistrationManager to see the differences between GCM and Matrix servers registration
-> the registration was not properly set when the GCM registration key was cleared on GCM servers (the registration key was retrieved but the matrix server registration was not done)
-> Should fix https://github.com/vector-im/vector-android/issues/255
make "turn the screen on for 3 seconds when a notification is received" configurable