### PR TITLE
Move read contact permission

### DIFF
--- a/vector/src/main/java/im/vector/activity/CommonActivityUtils.java
+++ b/vector/src/main/java/im/vector/activity/CommonActivityUtils.java
@@ -141,13 +141,10 @@ public class CommonActivityUtils {
     public static final int REQUEST_CODE_PERMISSION_AUDIO_IP_CALL = PERMISSION_RECORD_AUDIO;
     public static final int REQUEST_CODE_PERMISSION_VIDEO_IP_CALL = PERMISSION_CAMERA | PERMISSION_RECORD_AUDIO;
     public static final int REQUEST_CODE_PERMISSION_TAKE_PHOTO = PERMISSION_CAMERA | PERMISSION_WRITE_EXTERNAL_STORAGE;
-    public static final int REQUEST_CODE_PERMISSION_SEARCH_ROOM = PERMISSION_READ_CONTACTS;
+    public static final int REQUEST_CODE_PERMISSION_MEMBERS_SEARCH = PERMISSION_READ_CONTACTS;
     public static final int REQUEST_CODE_PERMISSION_MEMBER_DETAILS = PERMISSION_READ_CONTACTS;
     public static final int REQUEST_CODE_PERMISSION_HOME_ACTIVITY = PERMISSION_WRITE_EXTERNAL_STORAGE;
-
-    // start activity intent parameters
-    public static final String KEY_PERMISSIONS_READ_CONTACTS = "KEY_PERMISSIONS_READ_CONTACTS";
-
+    
     public static void logout(Activity activity, MXSession session, Boolean clearCredentials) {
         if (session.isAlive()) {
             // stop the service
@@ -531,7 +528,7 @@ public class CommonActivityUtils {
         } else if((REQUEST_CODE_PERMISSION_TAKE_PHOTO!=aPermissionsToBeGrantedBitMap)
                 && (REQUEST_CODE_PERMISSION_AUDIO_IP_CALL!=aPermissionsToBeGrantedBitMap)
                 && (REQUEST_CODE_PERMISSION_VIDEO_IP_CALL!=aPermissionsToBeGrantedBitMap)
-                && (REQUEST_CODE_PERMISSION_SEARCH_ROOM !=aPermissionsToBeGrantedBitMap)
+                && (REQUEST_CODE_PERMISSION_MEMBERS_SEARCH !=aPermissionsToBeGrantedBitMap)
                 && (REQUEST_CODE_PERMISSION_HOME_ACTIVITY !=aPermissionsToBeGrantedBitMap)
                 && (REQUEST_CODE_PERMISSION_MEMBER_DETAILS !=aPermissionsToBeGrantedBitMap)
                 ) {

--- a/vector/src/main/java/im/vector/activity/CommonActivityUtils.java
+++ b/vector/src/main/java/im/vector/activity/CommonActivityUtils.java
@@ -22,6 +22,7 @@ import android.app.Activity;
 import android.app.ActivityManager;
 import android.app.AlarmManager;
 import android.app.AlertDialog;
+import android.app.Dialog;
 import android.app.DownloadManager;
 import android.app.PendingIntent;
 import android.content.ActivityNotFoundException;
@@ -144,7 +145,7 @@ public class CommonActivityUtils {
     public static final int REQUEST_CODE_PERMISSION_MEMBERS_SEARCH = PERMISSION_READ_CONTACTS;
     public static final int REQUEST_CODE_PERMISSION_MEMBER_DETAILS = PERMISSION_READ_CONTACTS;
     public static final int REQUEST_CODE_PERMISSION_HOME_ACTIVITY = PERMISSION_WRITE_EXTERNAL_STORAGE;
-    
+
     public static void logout(Activity activity, MXSession session, Boolean clearCredentials) {
         if (session.isAlive()) {
             // stop the service
@@ -607,7 +608,16 @@ public class CommonActivityUtils {
                         }
                     }
                 });
-                permissionsInfoDialog.show();
+
+                Dialog dialog = permissionsInfoDialog.show();
+
+                dialog.setOnCancelListener(new DialogInterface.OnCancelListener() {
+                    @Override
+                    public void onCancel(DialogInterface dialog) {
+                        CommonActivityUtils.displayToast(aCallingActivity, aCallingActivity.getString(R.string.missing_permissions_warning));
+                    }
+                });
+
             } else {
                 // some permissions are not granted, ask permissions
                 if (isRequestPermissionRequired) {

--- a/vector/src/main/java/im/vector/activity/VectorHomeActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorHomeActivity.java
@@ -644,10 +644,8 @@ public class VectorHomeActivity extends AppCompatActivity implements VectorRecen
         switch(item.getItemId()) {
             // search in rooms content
             case R.id.ic_action_search_room:
-                // Check permission to access contacts
-                if(CommonActivityUtils.checkPermissions(CommonActivityUtils.REQUEST_CODE_PERMISSION_SEARCH_ROOM, this)){
-                    startUnifiedSearchActivity(CommonActivityUtils.PERMISSIONS_GRANTED);
-                }
+                final Intent searchIntent = new Intent(VectorHomeActivity.this, VectorUnifiedSearchActivity.class);
+                VectorHomeActivity.this.startActivity(searchIntent);
                 break;
 
             // search in rooms content
@@ -663,35 +661,9 @@ public class VectorHomeActivity extends AppCompatActivity implements VectorRecen
         return retCode;
     }
 
-    /**
-     * Start the VectorUnifiedSearchActivity.
-     * See {@link #onRequestPermissionsResult(int, String[], int[])}
-     * @param aIsContactPermissionGranted true to indicate the contact permission is granted, false otherwise
-     */
-    private void startUnifiedSearchActivity(boolean aIsContactPermissionGranted) {
-        // launch the "search in rooms" activity
-        final Intent searchIntent = new Intent(VectorHomeActivity.this, VectorUnifiedSearchActivity.class);
-        searchIntent.putExtra(CommonActivityUtils.KEY_PERMISSIONS_READ_CONTACTS,aIsContactPermissionGranted);
-        VectorHomeActivity.this.startActivity(searchIntent);
-    }
-
     @Override
     public void onRequestPermissionsResult(int aRequestCode,@NonNull String[] aPermissions, @NonNull int[] aGrantResults) {
-        if(aRequestCode == CommonActivityUtils.REQUEST_CODE_PERMISSION_SEARCH_ROOM){
-            if(Manifest.permission.READ_CONTACTS.equals(aPermissions[0])) {
-                if (PackageManager.PERMISSION_GRANTED == aGrantResults[0]) {
-                    Log.d(LOG_TAG, "## onRequestPermissionsResult(): READ_CONTACTS permission granted");
-                    startUnifiedSearchActivity(CommonActivityUtils.PERMISSIONS_GRANTED);
-                } else {
-                    Log.w(LOG_TAG, "## onRequestPermissionsResult(): READ_CONTACTS permission not granted");
-                    CommonActivityUtils.displayToast(this, "Due to missing permissions, some features may be missing..");
-                    startUnifiedSearchActivity(CommonActivityUtils.PERMISSIONS_DENIED);
-                }
-                ContactsManager.refreshLocalContactsSnapshot(this.getApplicationContext());
-            } else {
-                Log.w(LOG_TAG, "## onRequestPermissionsResult(): unexpected permission = " + aPermissions[0]);
-            }
-        } else if(aRequestCode == CommonActivityUtils.REQUEST_CODE_PERMISSION_VIDEO_IP_CALL){
+        if(aRequestCode == CommonActivityUtils.REQUEST_CODE_PERMISSION_VIDEO_IP_CALL){
             if(CommonActivityUtils.onPermissionResultVideoIpCall(this, aPermissions, aGrantResults)) {
                 startCall(mIncomingCallSessionId,mIncomingCallId);
             } else if(null != mIncomingCall) {

--- a/vector/src/main/java/im/vector/activity/VectorHomeActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorHomeActivity.java
@@ -60,7 +60,6 @@ import im.vector.MyPresenceManager;
 import im.vector.PublicRoomsManager;
 import im.vector.R;
 import im.vector.VectorApp;
-import im.vector.contacts.ContactsManager;
 import im.vector.fragments.VectorRecentsListFragment;
 import im.vector.ga.GAHelper;
 import im.vector.receiver.VectorUniversalLinkReceiver;

--- a/vector/src/main/java/im/vector/activity/VectorRoomActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorRoomActivity.java
@@ -1356,7 +1356,7 @@ public class VectorRoomActivity extends MXCActionBarActivity implements MatrixMe
             if(isCameraPermissionGranted){
                 launchCamera();
             } else {
-                CommonActivityUtils.displayToast(this, "Sorry.. Action not performed due to missing permissions");
+                CommonActivityUtils.displayToast(this, getString(R.string.missing_permissions_warning));
             }
         } else if(aRequestCode == CommonActivityUtils.REQUEST_CODE_PERMISSION_AUDIO_IP_CALL){
            if( CommonActivityUtils.onPermissionResultAudioIpCall(this, aPermissions, aGrantResults)) {

--- a/vector/src/main/java/im/vector/activity/VectorRoomDetailsActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorRoomDetailsActivity.java
@@ -183,7 +183,7 @@ public class VectorRoomDetailsActivity extends MXCActionBarActivity implements T
                     Log.d(LOG_TAG, "## onRequestPermissionsResult(): READ_CONTACTS permission granted");
                 } else {
                     Log.w(LOG_TAG, "## onRequestPermissionsResult(): READ_CONTACTS permission not granted");
-                    CommonActivityUtils.displayToast(this, "Due to missing permissions, some features may be missing..");
+                    CommonActivityUtils.displayToast(this, getString(R.string.missing_permissions_warning));
                 }
 
                 ContactsManager.refreshLocalContactsSnapshot(this.getApplicationContext());
@@ -233,11 +233,6 @@ public class VectorRoomDetailsActivity extends MXCActionBarActivity implements T
 
             // start the file search if the selected tab is the file one
             startFileSearch();
-        }
-
-        if (!mIsContactsPermissionChecked) {
-            mIsContactsPermissionChecked = true;
-            CommonActivityUtils.checkPermissions(CommonActivityUtils.REQUEST_CODE_PERMISSION_MEMBER_DETAILS, this);
         }
     }
 
@@ -363,6 +358,12 @@ public class VectorRoomDetailsActivity extends MXCActionBarActivity implements T
                 Log.d(LOG_TAG, "## onTabSelected() people frag attach");
             }
             mCurrentTabIndex = PEOPLE_TAB_INDEX;
+
+
+            if (!mIsContactsPermissionChecked) {
+                mIsContactsPermissionChecked = true;
+                CommonActivityUtils.checkPermissions(CommonActivityUtils.REQUEST_CODE_PERMISSION_MEMBER_DETAILS, this);
+            }
         }
         else if (fragmentTag.equals(TAG_FRAGMENT_SETTINGS_ROOM_DETAIL)) {
             onTabSelectSettingsFragment();

--- a/vector/src/main/java/im/vector/activity/VectorUnifiedSearchActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorUnifiedSearchActivity.java
@@ -424,7 +424,7 @@ public class VectorUnifiedSearchActivity extends VectorBaseSearchActivity implem
                 Log.d(LOG_TAG, "## onRequestPermissionsResult(): READ_CONTACTS permission granted");
             } else {
                 Log.d(LOG_TAG, "## onRequestPermissionsResult(): READ_CONTACTS permission not granted");
-                CommonActivityUtils.displayToast(this, "Due to missing permissions, some features may be missing..");
+                CommonActivityUtils.displayToast(this, getString(R.string.missing_permissions_warning));
             }
             ContactsManager.refreshLocalContactsSnapshot(this.getApplicationContext());
         }

--- a/vector/src/main/java/im/vector/activity/VectorUnifiedSearchActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorUnifiedSearchActivity.java
@@ -17,7 +17,9 @@
 package im.vector.activity;
 
 import android.annotation.SuppressLint;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
 import android.text.TextUtils;
@@ -31,8 +33,10 @@ import android.widget.Toast;
 import org.matrix.androidsdk.MXSession;
 import org.matrix.androidsdk.fragments.MatrixMessageListFragment;
 
+import im.vector.Manifest;
 import im.vector.Matrix;
 import im.vector.R;
+import im.vector.contacts.ContactsManager;
 import im.vector.fragments.VectorSearchPeopleListFragment;
 import im.vector.fragments.VectorSearchRoomsFilesListFragment;
 import im.vector.fragments.VectorSearchRoomsListFragment;
@@ -57,8 +61,6 @@ public class VectorUnifiedSearchActivity extends VectorBaseSearchActivity implem
     private int mSearchInPeopleTabIndex = -1;
     private int mSearchInFilesTabIndex = -1;
     private int mCurrentTabIndex = -1;
-
-    private boolean mIsPermissionGranted;
 
     // activity life cycle management:
     // - Bundle keys
@@ -103,17 +105,6 @@ public class VectorUnifiedSearchActivity extends VectorBaseSearchActivity implem
             Log.e(LOG_TAG, "No MXSession.");
             finish();
             return;
-        }
-
-        if(null != getIntent()){
-            mIsPermissionGranted = getIntent().getBooleanExtra(CommonActivityUtils.KEY_PERMISSIONS_READ_CONTACTS,CommonActivityUtils.PERMISSIONS_DENIED);
-        } else {
-            mIsPermissionGranted = CommonActivityUtils.PERMISSIONS_DENIED;
-        }
-
-        if(null != savedInstanceState){
-            // restore permissions status
-            mIsPermissionGranted = savedInstanceState.getBoolean(KEY_STATE_IS_PERMISSIONS_GRANTED,CommonActivityUtils.PERMISSIONS_DENIED);
         }
 
         // UI widgets binding & init fields
@@ -375,6 +366,9 @@ public class VectorUnifiedSearchActivity extends VectorBaseSearchActivity implem
             }
             fragment = mSearchInPeopleFragment;
             mCurrentTabIndex = mSearchInPeopleTabIndex;
+
+            // Check permission to access contacts
+            CommonActivityUtils.checkPermissions(CommonActivityUtils.REQUEST_CODE_PERMISSION_MEMBERS_SEARCH, this);
         }
 
         if (replace) {
@@ -423,6 +417,19 @@ public class VectorUnifiedSearchActivity extends VectorBaseSearchActivity implem
     public void onTabReselected(android.support.v7.app.ActionBar.Tab tab, FragmentTransaction ft) {
     }
 
+    @Override
+    public void onRequestPermissionsResult(int aRequestCode, @NonNull String[] aPermissions, @NonNull int[] aGrantResults) {
+        if (aRequestCode == CommonActivityUtils.REQUEST_CODE_PERMISSION_MEMBERS_SEARCH) {
+            if (PackageManager.PERMISSION_GRANTED == aGrantResults[0]) {
+                Log.d(LOG_TAG, "## onRequestPermissionsResult(): READ_CONTACTS permission granted");
+            } else {
+                Log.d(LOG_TAG, "## onRequestPermissionsResult(): READ_CONTACTS permission not granted");
+                CommonActivityUtils.displayToast(this, "Due to missing permissions, some features may be missing..");
+            }
+            ContactsManager.refreshLocalContactsSnapshot(this.getApplicationContext());
+        }
+    }
+
     //==============================================================================================================
     // Life cycle Activity methods
     //==============================================================================================================
@@ -442,9 +449,6 @@ public class VectorUnifiedSearchActivity extends VectorBaseSearchActivity implem
         if (!TextUtils.isEmpty(searchPattern)) {
             outState.putString(KEY_STATE_SEARCH_PATTERN, searchPattern);
         }
-
-        // save permissions status
-        outState.putBoolean(KEY_STATE_IS_PERMISSIONS_GRANTED, mIsPermissionGranted);
     }
 
     //==============================================================================================================

--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -43,6 +43,7 @@
     <string name="report_content">Report content</string>
     <string name="decline">Decline</string>
     <string name="active_call">Active call</string>
+    <string name="missing_permissions_warning">"Due to missing permissions, some features may be missing..</string>
 
     <!-- server urls -->
     <string name="vector_im_server_url">https://vector.im</string>


### PR DESCRIPTION
-> Unify search 
the read contact permissions is moved from the home activity to the unify search activity when the "People" tab is selected.

-> display a warning message when the user cancels the permissions explanation dialog.