### PR TITLE
Fix: [VoIP] start call icon must be always displayed #389

### DIFF
--- a/vector/src/main/res/values/strings.xml
+++ b/vector/src/main/res/values/strings.xml
@@ -47,6 +47,8 @@
     <string name="cannot_start_call">Cannot start the call, please try later</string>
     <string name="room_url">Room URL</string>
     <string name="missing_permissions_warning">"Due to missing permissions, some features may be missing..</string>
+    <string name="missing_permissions_to_start_conf_call">You need permission to invite to start a conference in this room</string>
+    <string name="missing_permissions_title_to_start_conf_call">Cannot start call</string>
 
     <!-- server urls -->
     <string name="vector_im_server_url">https://vector.im</string>


### PR DESCRIPTION
The call icon is always displayed and a popup is displayed in case the user has NOT the sufficient power level to ```invite```