### PR TITLE
Warning message when encrypted content is received (Fix #455)

### DIFF
--- a/vector/src/main/java/im/vector/activity/VectorRoomActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorRoomActivity.java
@@ -73,6 +73,7 @@ import org.matrix.androidsdk.rest.callback.ApiCallback;
 import org.matrix.androidsdk.rest.callback.SimpleApiCallback;
 import org.matrix.androidsdk.rest.model.Event;
 import org.matrix.androidsdk.rest.model.MatrixError;
+import org.matrix.androidsdk.rest.model.Message;
 import org.matrix.androidsdk.rest.model.PowerLevels;
 import org.matrix.androidsdk.rest.model.PublicRoom;
 import org.matrix.androidsdk.rest.model.RoomMember;
@@ -1322,7 +1323,7 @@ public class VectorRoomActivity extends MXCActionBarActivity implements MatrixMe
         // hide the header room
         enableActionBarHeader(HIDE_ACTION_BAR_HEADER);
 
-        sendMessage(body, html, "org.matrix.custom.html");
+        sendMessage(body, html, Message.FORMAT_MATRIX_HTML);
         mEditText.setText("");
     }
 

--- a/vector/src/main/java/im/vector/util/VectorRoomMediasSender.java
+++ b/vector/src/main/java/im/vector/util/VectorRoomMediasSender.java
@@ -33,6 +33,7 @@ import android.view.View;
 import android.widget.Toast;
 
 import org.matrix.androidsdk.db.MXMediasCache;
+import org.matrix.androidsdk.rest.model.Message;
 import org.matrix.androidsdk.util.ImageUtils;
 
 import java.io.File;
@@ -289,7 +290,7 @@ public class VectorRoomMediasSender {
         mVectorRoomActivity.runOnUiThread(new Runnable() {
             @Override
             public void run() {
-                mVectorRoomActivity.sendMessage(fText, fHtmlText, "org.matrix.custom.html");
+                mVectorRoomActivity.sendMessage(fText, fHtmlText, Message.FORMAT_MATRIX_HTML);
             }
         });
 


### PR DESCRIPTION
- Refactoring code to use a defined constant string for "org.matrix.custom.html"
- Add specific message ("Encrypted message") when an encrypted message (m.room.encrypted) is received.
