### PR TITLE
Fix The camera permission should be not required in the room settings…

### DIFF
--- a/vector/src/main/java/im/vector/activity/VectorRoomDetailsActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorRoomDetailsActivity.java
@@ -356,8 +356,14 @@ public class VectorRoomDetailsActivity extends MXCActionBarActivity implements T
             }
         }
         else if (fragmentTag.equals(TAG_FRAGMENT_SETTINGS_ROOM_DETAIL)) {
+            int permissionToBeGranted = CommonActivityUtils.REQUEST_CODE_PERMISSION_ROOM_DETAILS;
             onTabSelectSettingsFragment();
-            CommonActivityUtils.checkPermissions(CommonActivityUtils.REQUEST_CODE_PERMISSION_ROOM_DETAILS, this);
+
+            // remove camera permission request if the user has not enough power level
+            if(!CommonActivityUtils.isPowerLevelEnoughForAvatarUpdate(mRoom, mSession)) {
+                permissionToBeGranted &= ~CommonActivityUtils.PERMISSION_CAMERA;
+            }
+            CommonActivityUtils.checkPermissions(permissionToBeGranted, this);
             mCurrentTabIndex = SETTINGS_TAB_INDEX;
         }
         else if (fragmentTag.equals(TAG_FRAGMENT_FILES_DETAILS)) {


### PR DESCRIPTION
… if the user cannot update the room avatar. #532

- Before asking the camera permission, the user power level is checked against level required to update the avatar