### PR TITLE
Submit search query by pressing <Enter> on hardware keyboard

### DIFF
--- a/vector/src/main/java/im/vector/activity/VectorBaseSearchActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorBaseSearchActivity.java
@@ -115,7 +115,7 @@ public class VectorBaseSearchActivity extends MXCActionBarActivity {
         mPatternToSearchEditText.setOnEditorActionListener(new TextView.OnEditorActionListener() {
             @Override
             public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
-                if (actionId == EditorInfo.IME_ACTION_SEARCH) {
+                if ((actionId == EditorInfo.IME_ACTION_SEARCH) || ((null != event) && (event.getKeyCode() == KeyEvent.KEYCODE_ENTER))) {
                     onPatternUpdate(false);
                     return true;
                 }


### PR DESCRIPTION
Hi, this is a pull request that should let the \<Enter\> key submit a search, if a hardware keyboard is connected.

This is a "blind" PR, meaning I don't have a build environment set up, so please test carefully that it at least doesn't break anything. If you merge it or can provide a custom build, I'll take care of testing that it actually works.

More info in google docs for android.widget.TextView.OnEditorActionListener.

Hopefully takes care of #521