### PR TITLE
fix crash on searching a room #634

### DIFF
--- a/vector/src/main/java/im/vector/adapters/VectorRoomSummaryAdapter.java
+++ b/vector/src/main/java/im/vector/adapters/VectorRoomSummaryAdapter.java
@@ -107,8 +107,8 @@ public class VectorRoomSummaryAdapter extends BaseExpandableListAdapter {
     private boolean mForceDirectoryGroupDisplay;
 
     // public room search
-    private Integer mPublicRoomsCount;
-    private Integer mMatchedPublicRoomsCount;
+    private int mPublicRoomsCount = 0;
+    private int mMatchedPublicRoomsCount = 0;
 
     // the listener
     private final RoomEventListener mListener;
@@ -718,12 +718,12 @@ public class VectorRoomSummaryAdapter extends BaseExpandableListAdapter {
                 roomNameTxtView.setText(mContext.getResources().getString(R.string.directory_search_results_title));
 
                 if (!TextUtils.isEmpty(mSearchedPattern)) {
-                    if (null == mMatchedPublicRoomsCount) {
+                    if (mMatchedPublicRoomsCount < 1) {
                         roomMsgTxtView.setText(mContext.getResources().getString(R.string.directory_searching_title));
-                    } else if (mMatchedPublicRoomsCount < 2) {
+                    } else if (mMatchedPublicRoomsCount == 1) {
                         roomMsgTxtView.setText(mContext.getResources().getString(R.string.directory_search_room_for, mMatchedPublicRoomsCount, mSearchedPattern));
                     } else {
-                        String value = mMatchedPublicRoomsCount.toString();
+                        String value = String.valueOf(mMatchedPublicRoomsCount);
 
                         if (mMatchedPublicRoomsCount >= PublicRoomsManager.PUBLIC_ROOMS_LIMIT) {
                             value = "> " + PublicRoomsManager.PUBLIC_ROOMS_LIMIT;
@@ -732,12 +732,12 @@ public class VectorRoomSummaryAdapter extends BaseExpandableListAdapter {
                         roomMsgTxtView.setText(mContext.getResources().getString(R.string.directory_search_rooms_for, value, mSearchedPattern));
                     }
                 } else {
-                    if (null == mPublicRoomsCount) {
+                    if (mPublicRoomsCount < 1) {
                         roomMsgTxtView.setText(null);
-                    } else if (mPublicRoomsCount > 1) {
-                        roomMsgTxtView.setText(mContext.getResources().getString(R.string.directory_search_rooms, mPublicRoomsCount));
-                    } else {
+                    } else if (mPublicRoomsCount == 1) {
                         roomMsgTxtView.setText(mContext.getResources().getString(R.string.directory_search_room, mPublicRoomsCount));
+                    } else {
+                        roomMsgTxtView.setText(mContext.getResources().getString(R.string.directory_search_rooms, mPublicRoomsCount));
                     }
                 }
 
@@ -1054,7 +1054,7 @@ public class VectorRoomSummaryAdapter extends BaseExpandableListAdapter {
         if (!TextUtils.equals(trimmedPattern, mSearchedPattern)) {
 
             mSearchedPattern = trimmedPattern;
-            mMatchedPublicRoomsCount = null;
+            mMatchedPublicRoomsCount = 0;
 
             // refresh the layout
             this.notifyDataSetChanged();
@@ -1072,7 +1072,7 @@ public class VectorRoomSummaryAdapter extends BaseExpandableListAdapter {
      * Update the public rooms list count and refresh the display.
      * @param roomsListCount the new public rooms count
      */
-    public void setPublicRoomsCount(Integer roomsListCount) {
+    public void setPublicRoomsCount(int roomsListCount) {
         if (roomsListCount != mPublicRoomsCount) {
             mPublicRoomsCount = roomsListCount;
             super.notifyDataSetChanged();
@@ -1090,7 +1090,7 @@ public class VectorRoomSummaryAdapter extends BaseExpandableListAdapter {
      * Update the matched public rooms list count and refresh the display.
      * @param roomsListCount the new public rooms count
      */
-    public void setMatchedPublicRoomsCount(Integer roomsListCount) {
+    public void setMatchedPublicRoomsCount(int roomsListCount) {
         if (roomsListCount != mMatchedPublicRoomsCount) {
             mMatchedPublicRoomsCount = roomsListCount;
             super.notifyDataSetChanged();

--- a/vector/src/main/java/im/vector/fragments/VectorRecentsListFragment.java
+++ b/vector/src/main/java/im/vector/fragments/VectorRecentsListFragment.java
@@ -19,9 +19,9 @@ package im.vector.fragments;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.v4.app.Fragment;
-import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -46,6 +46,10 @@ import org.matrix.androidsdk.rest.model.Event;
 import org.matrix.androidsdk.rest.model.MatrixError;
 import org.matrix.androidsdk.util.BingRulesManager;
 import org.matrix.androidsdk.util.EventUtils;
+
+import java.util.HashMap;
+import java.util.List;
+
 import im.vector.Matrix;
 import im.vector.PublicRoomsManager;
 import im.vector.R;
@@ -56,9 +60,6 @@ import im.vector.activity.VectorRoomActivity;
 import im.vector.adapters.VectorRoomSummaryAdapter;
 import im.vector.services.EventStreamService;
 import im.vector.view.RecentsExpandableListView;
-
-import java.util.HashMap;
-import java.util.List;
 
 public class VectorRecentsListFragment extends Fragment implements VectorRoomSummaryAdapter.RoomEventListener, RecentsExpandableListView.DragAndDropEventsListener {
 
@@ -306,10 +307,13 @@ public class VectorRecentsListFragment extends Fragment implements VectorRoomSum
             public void run() {
 
                 // trigger a public room refresh if the list was not initialized or too old (5 mins)
-                if (((null == PublicRoomsManager.getPublicRoomsCount()) || ((System.currentTimeMillis() - mLatestPublicRoomsRefresh) < (5 * 60000))) && (!mIsLoadingPublicRooms)) {
+                if (!mIsLoadingPublicRooms &&
+                        (PublicRoomsManager.PUBLIC_ROOMS_NOT_INITIALIZED == PublicRoomsManager.getPublicRoomsCount()
+                                || (System.currentTimeMillis() - mLatestPublicRoomsRefresh) < (5 * 60000))) {
+
                     PublicRoomsManager.refreshPublicRoomsCount(new PublicRoomsManager.PublicRoomsManagerListener() {
                         @Override
-                        public void onPublicRoomsCountRefresh(final Integer publicRoomsCount) {
+                        public void onPublicRoomsCountRefresh(final int publicRoomsCount) {
                             if (null != getActivity()) {
                                 getActivity().runOnUiThread(new Runnable() {
                                     @Override


### PR DESCRIPTION
- changed room count from Integer to int (adapted related code)
- minor refactoring

I could be wrong, but I think that the room count can be an int (instead of Integer).
This way it does not have to be null checked and can be used more safely. 
I also couldn't quite resist and did some minor refactoring where I changed code.

If this is too much of a change for this small issue, you could just do this instead:

```
/**
* @return the matched public rooms count
*/
public int getMatchedPublicRoomsCount() {
    return null == mMatchedPublicRoomsCount ? 0 : mMatchedPublicRoomsCount.intValue();
}
```
