### PR TITLE
Fix Implementing remaining 1:1 semantics across the UI #618

### DIFF
--- a/vector/src/main/java/im/vector/activity/CommonActivityUtils.java
+++ b/vector/src/main/java/im/vector/activity/CommonActivityUtils.java
@@ -1266,7 +1266,7 @@ public class CommonActivityUtils {
         if((null == aSession) || (null == fromActivity) || TextUtils.isEmpty(aRoomId)) {
             Log.d(LOG_TAG, "## setDirectChatRoom(): failure - invalid input parameters");
         } else {
-            aSession.toogleDirectChatRoom(aRoomId, aParticipantUserId, new ApiCallback<Void>() {
+            aSession.toggleDirectChatRoom(aRoomId, aParticipantUserId, new ApiCallback<Void>() {
                 @Override
                 public void onSuccess(Void info) {
                     HashMap<String, Object> params = new HashMap<>();

--- a/vector/src/main/java/im/vector/activity/VectorMemberDetailsActivity.java
+++ b/vector/src/main/java/im/vector/activity/VectorMemberDetailsActivity.java
@@ -773,19 +773,11 @@ public class VectorMemberDetailsActivity extends MXCActionBarActivity implements
             // direct chats management
 
             // list other direct rooms
-            List<String> roomIds = mSession.getDirectChatRoomIdsList();
-
+            List<String> roomIds = mSession.getDirectChatRoomIdsList(mMemberId);
             for(String roomId : roomIds) {
-                // not the current one
-                if (!TextUtils.equals(mRoomId, roomId)) {
-                    Room room = mSession.getDataHandler().getRoom(roomId);
-                    if (null != room) {
-                        RoomMember member = room.getMember(mMemberId);
-
-                        if ((null != member) && TextUtils.equals(member.membership, RoomMember.MEMBERSHIP_JOIN)) {
-                            directMessagesActions.add(new VectorMemberDetailsAdapter.AdapterMemberActionItems(room));
-                        }
-                    }
+                Room room = mSession.getDataHandler().getRoom(roomId);
+                if (null != room) {
+                    directMessagesActions.add(new VectorMemberDetailsAdapter.AdapterMemberActionItems(room));
                 }
             }
 

--- a/vector/src/main/java/im/vector/adapters/VectorRoomSummaryAdapter.java
+++ b/vector/src/main/java/im/vector/adapters/VectorRoomSummaryAdapter.java
@@ -95,7 +95,6 @@ public class VectorRoomSummaryAdapter extends BaseExpandableListAdapter {
     private int mDirectoryGroupPosition = -1;  // public rooms index
     private int mInvitedGroupPosition = -1;  // "Invited" index
     private int mFavouritesGroupPosition = -1;// "Favourites" index
-    private int mDirectChatsGroupPosition = -1;  // "People" index
     private int mNoTagGroupPosition = -1;    // "Rooms" index
     private int mLowPriorGroupPosition = -1;  // "Low Priority" index
 
@@ -197,11 +196,7 @@ public class VectorRoomSummaryAdapter extends BaseExpandableListAdapter {
         }
         else if (mInvitedGroupPosition == groupPosition) {
             retValue = mContext.getResources().getString(R.string.room_recents_invites);
-        }
-        else if (mDirectChatsGroupPosition == groupPosition) {
-            retValue = mContext.getResources().getString(R.string.room_recents_pepole);
-        }
-        else {
+        } else {
             // unknown section
             retValue = "??";
         }
@@ -316,7 +311,6 @@ public class VectorRoomSummaryAdapter extends BaseExpandableListAdapter {
         mFavouritesGroupPosition = -1;
         mNoTagGroupPosition = -1;
         mLowPriorGroupPosition = -1;
-        mDirectChatsGroupPosition = -1;
 
         if(null != aRoomSummaryCollection) {
 
@@ -330,7 +324,6 @@ public class VectorRoomSummaryAdapter extends BaseExpandableListAdapter {
             // ArrayLists allocations: will contain the RoomSummary objects deduced from roomIdsWithTag()
             ArrayList<RoomSummary> inviteRoomSummaryList = new ArrayList<>();
             ArrayList<RoomSummary> favouriteRoomSummaryList = new ArrayList<>(favouriteRoomIdList.size());
-            ArrayList<RoomSummary> directChatRoomSummaryList = new ArrayList<>(mDirectChatRoomIdsList.size());
             ArrayList<RoomSummary> lowPriorityRoomSummaryList = new ArrayList<>();
             ArrayList<RoomSummary> noTagRoomSummaryList = new ArrayList<>(lowPriorityRoomIdList.size());
 
@@ -358,8 +351,6 @@ public class VectorRoomSummaryAdapter extends BaseExpandableListAdapter {
                             // update the favourites list
                             // the favorites are ordered
                             favouriteRoomSummaryList.set(pos, roomSummary);
-                        } else if (mDirectChatRoomIdsList.indexOf(roomSummaryId) >= 0) {
-                            directChatRoomSummaryList.add(roomSummary);
                         } else if ((pos = lowPriorityRoomIdList.indexOf(roomSummaryId)) >= 0) {
                             // update the low priority list
                             // the low priority are ordered
@@ -435,12 +426,6 @@ public class VectorRoomSummaryAdapter extends BaseExpandableListAdapter {
                 groupIndex++;
             }
 
-            if (0 != directChatRoomSummaryList.size()) {
-                summaryListByGroupsRetValue.add(directChatRoomSummaryList);
-                mDirectChatsGroupPosition = groupIndex; // save section index
-                groupIndex++;
-            }
-
             // no tag
             if (0 != noTagRoomSummaryList.size()) {
                 summaryListByGroupsRetValue.add(noTagRoomSummaryList);
@@ -466,7 +451,6 @@ public class VectorRoomSummaryAdapter extends BaseExpandableListAdapter {
                 mFavouritesGroupPosition--;
                 mNoTagGroupPosition--;
                 mLowPriorGroupPosition--;
-                mDirectChatsGroupPosition--;
             }
         }
 
@@ -1197,14 +1181,5 @@ public class VectorRoomSummaryAdapter extends BaseExpandableListAdapter {
      */
     public boolean isLowPriorityRoomPosition(int groupPos) {
         return mLowPriorGroupPosition == groupPos;
-    }
-
-    /**
-     * Tell if a group position is the direct chat one.
-     * @param groupPos the proup position.
-     * @return true if the  group position is the direct chat one.
-     */
-    public boolean isDirectChatRoomPosition(int groupPos) {
-        return mDirectChatsGroupPosition == groupPos;
     }
 }

--- a/vector/src/main/java/im/vector/fragments/VectorRecentsListFragment.java
+++ b/vector/src/main/java/im/vector/fragments/VectorRecentsListFragment.java
@@ -756,7 +756,7 @@ public class VectorRecentsListFragment extends Fragment implements VectorRoomSum
             mSession.getDataHandler().addListener(mEventsListener);
 
 
-            mSession.toogleDirectChatRoom(roomId, null, new ApiCallback<Void>() {
+            mSession.toggleDirectChatRoom(roomId, null, new ApiCallback<Void>() {
                 @Override
                 public void onSuccess(Void info) {
                     if (null != getActivity()) {

--- a/vector/src/main/java/im/vector/fragments/VectorRecentsListFragment.java
+++ b/vector/src/main/java/im/vector/fragments/VectorRecentsListFragment.java
@@ -433,8 +433,6 @@ public class VectorRecentsListFragment extends Fragment implements VectorRoomSum
                             isExpanded = preferences.getBoolean(KEY_EXPAND_STATE_LOW_PRIORITY_GROUP, CommonActivityUtils.GROUP_IS_EXPANDED);
                         } else if (mAdapter.isDirectoryGroupPosition(groupIndex)) { // public rooms (search mode)
                             isExpanded = preferences.getBoolean(KEY_EXPAND_STATE_LOW_PRIORITY_GROUP, CommonActivityUtils.GROUP_IS_EXPANDED);
-                        } else if (mAdapter.isDirectChatRoomPosition(groupIndex)) { // "People" group
-                            isExpanded = preferences.getBoolean(KEY_EXPAND_STATE_DIRECT_MESSAGES_GROUP, CommonActivityUtils.GROUP_IS_EXPANDED);
                         } else {
                             // unknown group index, just skipp
                             break;
@@ -471,8 +469,6 @@ public class VectorRecentsListFragment extends Fragment implements VectorRoomSum
                 groupKey = KEY_EXPAND_STATE_LOW_PRIORITY_GROUP;
             } else if(mAdapter.isDirectoryGroupPosition(aGroupPosition)) { // public rooms (search mode)
                 groupKey = KEY_EXPAND_STATE_LOW_PRIORITY_GROUP;
-            } else if(mAdapter.isDirectChatRoomPosition(aGroupPosition)) { // Direct messages
-                groupKey = KEY_EXPAND_STATE_DIRECT_MESSAGES_GROUP;
             } else {
                 // unknown group position, just skipp
                 Log.w(LOG_TAG, "## updateGroupExpandStatus(): Failure - Unknown group: "+aGroupPosition);
@@ -760,7 +756,7 @@ public class VectorRecentsListFragment extends Fragment implements VectorRoomSum
             mSession.getDataHandler().addListener(mEventsListener);
 
 
-            mSession.toogleDirectChatRoom(roomId, new ApiCallback<Void>() {
+            mSession.toogleDirectChatRoom(roomId, null, new ApiCallback<Void>() {
                 @Override
                 public void onSuccess(Void info) {
                     if (null != getActivity()) {

--- a/vector/src/main/res/layout/adapter_item_vector_recent_room.xml
+++ b/vector/src/main/res/layout/adapter_item_vector_recent_room.xml
@@ -33,7 +33,7 @@
             android:layout_width="20dp"
             android:layout_height="20dp"
             android:layout_marginLeft="30dp"
-            android:layout_alignBottom="@+id/room_avatar_image_view"
+            android:layout_alignTop="@+id/room_avatar_image_view"
             android:layout_alignLeft="@+id/room_avatar_image_view"
             android:visibility="gone"
             android:src="@drawable/icon_person" />

--- a/vector/src/main/res/layout/vector_adapter_member_details_items.xml
+++ b/vector/src/main/res/layout/vector_adapter_member_details_items.xml
@@ -35,7 +35,7 @@
                 android:layout_width="16dp"
                 android:layout_height="16dp"
                 android:layout_marginLeft="24dp"
-                android:layout_alignBottom="@+id/room_avatar_image_view"
+                android:layout_alignTop="@+id/room_avatar_image_view"
                 android:layout_alignLeft="@+id/room_avatar_image_view"
                 android:src="@drawable/icon_person" />
 


### PR DESCRIPTION
- remove PEOPLE section
- update direct chat icon position
 - if a direct chat already exists with a given participant, it must be reused when "start chat" action is performed on the same participant
 - when a "start chat" action is performed with only one participant, it will be tagged as direct message (is_direct=true)